### PR TITLE
Admin - Fix infinite loop on navigate

### DIFF
--- a/apps/admin/src/Routes.tsx
+++ b/apps/admin/src/Routes.tsx
@@ -41,7 +41,7 @@ const HomeContainer = () => {
     }
     if (isConnected && !profile) {
       navigate(`/${address}`);
-      window.location.href = `/${address}`;
+      window.location.href = `#/${address}`;
     }
   }, [isConnected, address, profile, navigate]);
   return (


### PR DESCRIPTION
Quick fix to remove an infinite loop that happens when the admin app opens (root) and tries to redirect to Home view with connected account