### PR TITLE
fix exponential overload error

### DIFF
--- a/apps/admin/src/pages/Members.tsx
+++ b/apps/admin/src/pages/Members.tsx
@@ -138,10 +138,10 @@ export const Members = () => {
             <div className="hide-sm">
               {votingPowerPercentage(dao?.totalShares || '0', value)}
               {' %'}
-              {delegatedShares > 0 && (
+              {Number(delegatedShares) > 0 && (
                 <Tooltip
                   content={`${formatValueTo({
-                    value: fromWei(delegatedShares.toFixed()),
+                    value: fromWei(delegatedShares),
                     decimals: 2,
                     format: 'number',
                   })} voting tokens are delegated to this member`}

--- a/libs/utils/src/utils/general.ts
+++ b/libs/utils/src/utils/general.ts
@@ -58,8 +58,10 @@ export const memberUsdValueShare = (
 export const sharesDelegatedToMember = (
   delegateShares: string | number,
   memberShares: string | number
-): number => {
-  return Number(delegateShares) - Number(memberShares);
+) => {
+  const val = Number(delegateShares) - Number(memberShares);
+  if (!Number.isSafeInteger(val)) return BigInt(val).toString();
+  return val.toString();
 };
 
 export const lowerCaseLootToken = (tokenName?: string): string => {


### PR DESCRIPTION
## GitHub Issue

Fromwei crashes when it receives an exponential (ex. 2.343 e+21)
SharesDelegatedToMember returns an exponential when it calculates a high share amt. 


This causes a crash on admin

https://admin.daohaus.fun/#/molochv3/0x5/0xc035dd7cda32ae73f0f306ed56658527aad47648/members

## Changes

Fixed it by checking if the number is unsafe and converting to big int. 

We may need to do this with the rest of our conversion functions. 

## Packages Added

--

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
