### PR TITLE
Add object argtype to formbuilder

### DIFF
--- a/apps/admin/src/components/ActionDisplay.tsx
+++ b/apps/admin/src/components/ActionDisplay.tsx
@@ -172,9 +172,12 @@ const ValueDisplay = ({
   isMobile?: boolean;
 }) => {
   if (Array.isArray(argValue)) {
-    const displayValue = argType === 'tuple'
-      ? Object.entries(Object.assign({}, argValue)).filter(entry => !isNumberish(entry[0]))
-      : argValue;
+    const displayValue =
+      argType === 'tuple'
+        ? Object.entries(Object.assign({}, argValue)).filter(
+            (entry) => !isNumberish(entry[0])
+          )
+        : argValue;
     return (
       <>
         {displayValue.map((value, index) => {

--- a/apps/admin/src/components/ActionDisplay.tsx
+++ b/apps/admin/src/components/ActionDisplay.tsx
@@ -1,4 +1,4 @@
-import { ArgType, isEthAddress } from '@daohaus/utils';
+import { ArgType, isEthAddress, isNumberish } from '@daohaus/utils';
 
 import { isValidNetwork, ValidNetwork } from '@daohaus/keychain-utils';
 import {
@@ -145,6 +145,7 @@ export const ActionDisplay = ({
                   </DataSm>
                   <ValueDisplay
                     argValue={arg.value}
+                    argType={arg.type}
                     network={network}
                     isMobile={isMobile}
                   />
@@ -161,23 +162,29 @@ export const ActionDisplay = ({
 
 const ValueDisplay = ({
   argValue,
+  argType,
   network,
   isMobile,
 }: {
   argValue: ArgType;
+  argType?: string;
   network?: ValidNetwork;
   isMobile?: boolean;
 }) => {
   if (Array.isArray(argValue)) {
+    const displayValue = argType === 'tuple'
+      ? Object.entries(Object.assign({}, argValue)).filter(entry => !isNumberish(entry[0]))
+      : argValue;
     return (
       <>
-        {argValue.map((value, index) => {
+        {displayValue.map((value, index) => {
           return (
             <div className="space" key={`argValue${index}`}>
               <ValueDisplay
                 argValue={
                   Array.isArray(value) ? `${value[0]}: ${value[1]}` : value
                 }
+                argType={argType}
                 network={network}
               />
               {index + 1 < argValue?.length && <Divider />}

--- a/apps/admin/src/components/customFields/MultisendActions.tsx
+++ b/apps/admin/src/components/customFields/MultisendActions.tsx
@@ -54,6 +54,13 @@ const ActionContainer = styled.div`
 
 const REGEX_ARRAY_TYPE = /\[(([1-9]*)([0-9]+))?\]/g;
 
+const mapFieldToArgType = (fieldType: string) => {
+  if (fieldType.includes('address')) return 'ethAddress';
+  if (fieldType.includes('int') || fieldType === 'bool') return 'number';
+  if (fieldType === 'tuple') return 'object';
+  return undefined; // means plain string for other cases
+};
+
 const createActionField = (
   actionId: string,
   input: JsonFragmentType
@@ -140,13 +147,7 @@ const createActionField = (
   }
   return {
     ...fieldBase,
-    expectType: input.type?.includes('address')
-      ? 'ethAddress'
-      : input.type === 'tuple'
-      ? 'object'
-      : input.type?.includes('int') || input.type === 'bool'
-      ? 'number'
-      : undefined, // plain string for other cases
+    expectType: mapFieldToArgType(input.type || ''),
   };
 };
 

--- a/apps/admin/src/components/customFields/MultisendActions.tsx
+++ b/apps/admin/src/components/customFields/MultisendActions.tsx
@@ -65,8 +65,10 @@ const createActionField = (
     required: 'Value is required',
   };
   if (input.type === 'tuple') {
-    newRules['setValueAs'] = (val: string) => isObject(val) && typeof val === 'string' ? JSON.parse(val) : val;
-    newRules['validate'] = (val) => ignoreEmptyVal(val, (val) => ValidateField.object(val));
+    newRules['setValueAs'] = (val: string) =>
+      isObject(val) && typeof val === 'string' ? JSON.parse(val) : val;
+    newRules['validate'] = (val) =>
+      ignoreEmptyVal(val, (val) => ValidateField.object(val));
   }
   const fieldBase = {
     id: `tx.${actionId}.fields.${input.name}`,
@@ -403,7 +405,10 @@ const Action = ({
       argFieldsIds.length &&
       argFieldsIds
         .map((id) => id.split('.').reduce((data, curr) => data[curr], values))
-        .every((arg: unknown) => (arg as string)?.length > 0 || typeof arg === 'object')
+        .every(
+          (arg: unknown) =>
+            (arg as string)?.length > 0 || typeof arg === 'object'
+        )
     ) {
       encodeAction(
         { ...values.tx?.[actionId]?.fields },

--- a/libs/form-builder/src/components/CoreFieldLookup.ts
+++ b/libs/form-builder/src/components/CoreFieldLookup.ts
@@ -15,6 +15,7 @@ import { CheckRender } from './CheckRender';
 import { SegmentRender } from './SegmentRender';
 import { SplitColumnLayout } from './SplitRender';
 import { ToWeiInput } from './ToWeiInput';
+import { TupleObject } from './TupleObject';
 
 export const CoreFieldLookup = {
   input: WrappedInput,
@@ -33,4 +34,5 @@ export const CoreFieldLookup = {
   shamanPermissions: ShamanPermission,
   timePicker: TimePicker,
   toWeiInput: ToWeiInput,
+  tupleObject: TupleObject,
 };

--- a/libs/form-builder/src/components/TupleObject.tsx
+++ b/libs/form-builder/src/components/TupleObject.tsx
@@ -1,0 +1,17 @@
+import { RegisterOptions } from 'react-hook-form';
+import { Buildable, Field, WrappedTextArea } from '@daohaus/ui';
+import {
+  ignoreEmptyVal,
+  isObject,
+  ValidateField,
+} from '@daohaus/utils';
+
+export const TupleObject = (props: Buildable<Field>) => {
+  const newRules: RegisterOptions = {
+    setValueAs: (val: string) => (isObject(val) ? JSON.parse(val) : val),
+    validate: (val) => ignoreEmptyVal(val, (val) => ValidateField.object(val)),
+    ...props.rules,
+  };
+
+  return <WrappedTextArea {...props} rules={newRules} />;
+};

--- a/libs/form-builder/src/components/TupleObject.tsx
+++ b/libs/form-builder/src/components/TupleObject.tsx
@@ -1,10 +1,6 @@
 import { RegisterOptions } from 'react-hook-form';
 import { Buildable, Field, WrappedTextArea } from '@daohaus/ui';
-import {
-  ignoreEmptyVal,
-  isObject,
-  ValidateField,
-} from '@daohaus/utils';
+import { ignoreEmptyVal, isObject, ValidateField } from '@daohaus/utils';
 
 export const TupleObject = (props: Buildable<Field>) => {
   const newRules: RegisterOptions = {

--- a/libs/utils/src/utils/typeguards.ts
+++ b/libs/utils/src/utils/typeguards.ts
@@ -16,11 +16,24 @@ export const isEthAddress = (item: unknown): item is EthAddress =>
   isString(item) && ethers.utils.isAddress(item);
 // general 'is' guards that help us verify shapes of data
 
+export const isObject = (item: unknown) => {
+  if (typeof item === 'object') return true;
+  try {
+    if (isString(item)) {
+      JSON.parse(item as string);
+      return true;
+    }
+    return false;
+  } catch(error) {
+    return false;
+  }
+};
+
 export const isArgType = (item: unknown): item is ArgType => {
   if (isArray(item)) {
     return item.every(isArgType);
   }
-  return isString(item) || isNumber(item) || isBoolean(item);
+  return isString(item) || isNumber(item) || isBoolean(item) || isObject(item);
 };
 
 export const isNumberString = (item: unknown) =>

--- a/libs/utils/src/utils/typeguards.ts
+++ b/libs/utils/src/utils/typeguards.ts
@@ -24,7 +24,7 @@ export const isObject = (item: unknown) => {
       return true;
     }
     return false;
-  } catch(error) {
+  } catch (error) {
     return false;
   }
 };

--- a/libs/utils/src/utils/typeguards.ts
+++ b/libs/utils/src/utils/typeguards.ts
@@ -17,7 +17,7 @@ export const isEthAddress = (item: unknown): item is EthAddress =>
 // general 'is' guards that help us verify shapes of data
 
 export const isObject = (item: unknown) => {
-  if (typeof item === 'object') return true;
+  if (item instanceof Object) return true;
   try {
     if (isString(item)) {
       JSON.parse(item as string);

--- a/libs/utils/src/utils/validation.ts
+++ b/libs/utils/src/utils/validation.ts
@@ -37,7 +37,7 @@ export const ValidateField = {
     isNumberish(val) && Number(val) >= range[0] && Number(val) <= range[1]
       ? true
       : ValErrMsgs.percent,
-  object: (val: unknown) => isObject(val) ? true : ValErrMsgs.object,
+  object: (val: unknown) => (isObject(val) ? true : ValErrMsgs.object),
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/utils/src/utils/validation.ts
+++ b/libs/utils/src/utils/validation.ts
@@ -3,6 +3,7 @@ import {
   isArray,
   isBoolean,
   isEthAddress,
+  isObject,
   isNumberish,
   isString,
 } from './typeguards';
@@ -15,6 +16,7 @@ export const ValErrMsgs = {
   url: 'Field must be a valid URL',
   email: 'Field must be a valid email',
   percent: 'Field must be a valid percentage',
+  object: 'Field must be a valid JSON Object',
 };
 export const ValidateField = {
   number: (val: unknown) => (isNumberish(val) ? true : ValErrMsgs.number),
@@ -35,6 +37,7 @@ export const ValidateField = {
     isNumberish(val) && Number(val) >= range[0] && Number(val) <= range[1]
       ? true
       : ValErrMsgs.percent,
+  object: (val: unknown) => isObject(val) ? true : ValErrMsgs.object,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## GitHub Issue

Closes #153 

## Changes

implements Object arg type on formbuilder so it is possible to create form Txs & make contract calls to methods that include Structs (tuple type) as parameters

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
