### PR TITLE
Generic multisend argtype

### DIFF
--- a/apps/admin/src/legos/contracts.ts
+++ b/apps/admin/src/legos/contracts.ts
@@ -61,4 +61,10 @@ export const CONTRACT: Record<string, ContractLego> = {
     abi: LOCAL_ABI.GNOSIS_MODULE,
     targetAddress: '.formValues.safeAddress',
   },
+  GNOSIS_MULTISEND: {
+    type: 'static',
+    contractName: 'GNOSIS_MULTISEND',
+    abi: LOCAL_ABI.GNOSIS_MULTISEND,
+    targetAddress: CONTRACT_KEYCHAINS.GNOSIS_MULTISEND,
+  },
 };

--- a/apps/admin/src/legos/tx.ts
+++ b/apps/admin/src/legos/tx.ts
@@ -23,6 +23,42 @@ const nestInArray = (arg: ValidArgType | ValidArgType[]): NestedArray => {
 };
 
 export const TX: Record<string, TXLego> = {
+  TEST: {
+    id: 'TEST',
+    contract: CONTRACT.GNOSIS_MULTISEND,
+    method: 'multiSend',
+    args: [
+      {
+        type: 'encodeMulticall',
+        actions: [
+          {
+            contract: CONTRACT.POSTER,
+            method: 'post',
+            operations: { type: 'static', value: 1 },
+            args: [
+              {
+                type: 'static',
+                value: 'Test',
+              },
+              { type: 'static', value: POSTER_TAGS.daoDatabaseProposal },
+            ],
+          },
+          {
+            contract: CONTRACT.POSTER,
+            method: 'post',
+            operations: { type: 'static', value: 1 },
+            args: [
+              {
+                type: 'static',
+                value: 'Test',
+              },
+              { type: 'static', value: POSTER_TAGS.daoDatabaseProposal },
+            ],
+          },
+        ],
+      },
+    ],
+  },
   POST_SIGNAL: buildMultiCallTX({
     id: 'POST_SIGNAL',
     JSONDetails: {

--- a/apps/admin/src/legos/tx.ts
+++ b/apps/admin/src/legos/tx.ts
@@ -39,6 +39,7 @@ export const TX: Record<string, TXLego> = {
       {
         contract: CONTRACT.POSTER,
         method: 'post',
+        operations: { type: 'static', value: 0 },
         args: [
           {
             type: 'JSONDetails',

--- a/apps/admin/src/legos/tx.ts
+++ b/apps/admin/src/legos/tx.ts
@@ -23,42 +23,6 @@ const nestInArray = (arg: ValidArgType | ValidArgType[]): NestedArray => {
 };
 
 export const TX: Record<string, TXLego> = {
-  TEST: {
-    id: 'TEST',
-    contract: CONTRACT.GNOSIS_MULTISEND,
-    method: 'multiSend',
-    args: [
-      {
-        type: 'encodeMulticall',
-        actions: [
-          {
-            contract: CONTRACT.POSTER,
-            method: 'post',
-            operations: { type: 'static', value: 1 },
-            args: [
-              {
-                type: 'static',
-                value: 'Test',
-              },
-              { type: 'static', value: POSTER_TAGS.daoDatabaseProposal },
-            ],
-          },
-          {
-            contract: CONTRACT.POSTER,
-            method: 'post',
-            operations: { type: 'static', value: 1 },
-            args: [
-              {
-                type: 'static',
-                value: 'Test',
-              },
-              { type: 'static', value: POSTER_TAGS.daoDatabaseProposal },
-            ],
-          },
-        ],
-      },
-    ],
-  },
   POST_SIGNAL: buildMultiCallTX({
     id: 'POST_SIGNAL',
     JSONDetails: {

--- a/apps/admin/src/pages/DaoOverview.tsx
+++ b/apps/admin/src/pages/DaoOverview.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import {
+  Button,
   Card,
   DataIndicator,
   H4,
@@ -15,6 +16,8 @@ import {
   fromWei,
   lowerCaseLootToken,
 } from '@daohaus/utils';
+import { TX } from '../legos/tx';
+import { useTxBuilder } from '@daohaus/tx-builder';
 
 const OverviewCard = styled(Card)`
   width: 64rem;
@@ -44,9 +47,21 @@ const DataGrid = styled.div`
 
 export function DaoOverview() {
   const { dao } = useDao();
+  const { fireTransaction } = useTxBuilder();
+  const test = () => {
+    fireTransaction({
+      tx: TX.TEST,
+      lifeCycleFns: {
+        onTxSuccess: (txHash) => {
+          console.log('Success');
+        },
+      },
+    });
+  };
 
   return (
     <SingleColumnLayout>
+      <Button onClick={test}>Test</Button>
       {dao && (
         <>
           <OverviewCard>

--- a/apps/admin/src/pages/DaoOverview.tsx
+++ b/apps/admin/src/pages/DaoOverview.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 import {
-  Button,
   Card,
   DataIndicator,
   H4,
@@ -16,8 +15,6 @@ import {
   fromWei,
   lowerCaseLootToken,
 } from '@daohaus/utils';
-import { TX } from '../legos/tx';
-import { useTxBuilder } from '@daohaus/tx-builder';
 
 const OverviewCard = styled(Card)`
   width: 64rem;
@@ -47,21 +44,9 @@ const DataGrid = styled.div`
 
 export function DaoOverview() {
   const { dao } = useDao();
-  const { fireTransaction } = useTxBuilder();
-  const test = () => {
-    fireTransaction({
-      tx: TX.TEST,
-      lifeCycleFns: {
-        onTxSuccess: (txHash) => {
-          console.log('Success');
-        },
-      },
-    });
-  };
 
   return (
     <SingleColumnLayout>
-      <Button onClick={test}>Test</Button>
       {dao && (
         <>
           <OverviewCard>

--- a/libs/tx-builder/src/utils/args.ts
+++ b/libs/tx-builder/src/utils/args.ts
@@ -106,7 +106,7 @@ export const processArg = async ({
       )
     );
   }
-  if (arg?.type === 'multicall') {
+  if (arg?.type === 'multicall' || arg.type === 'encodeMulticall') {
     const result = await handleMulticallArg({
       arg,
       chainId,

--- a/libs/tx-builder/src/utils/multicall.ts
+++ b/libs/tx-builder/src/utils/multicall.ts
@@ -8,6 +8,7 @@ import {
   encodeValues,
   EstmimateGas,
   EthAddress,
+  EncodeMulticall,
   JSONDetailsSearch,
   MulticallAction,
   MulticallArg,
@@ -99,7 +100,7 @@ export const txActionToMetaTx = ({
   if (typeof encodedData !== 'string') {
     throw new Error(encodedData.message);
   }
-
+  console.log('operation', operation);
   return {
     to: address,
     data: encodedData,
@@ -199,7 +200,7 @@ export const handleMulticallArg = async ({
   pinataApiKeys,
   explorerKeys,
 }: {
-  arg: MulticallArg;
+  arg: MulticallArg | EncodeMulticall;
   chainId: ValidNetwork;
   localABIs: Record<string, ABI>;
   appState: ArbitraryState;
@@ -242,7 +243,7 @@ export const handleMulticallArg = async ({
             explorerKeys,
           })
         : 0;
-
+      console.log('processedOperations', processedOperations);
       // Early return if encoded data is passed and args do not need processing
       if (data) {
         return {
@@ -289,6 +290,15 @@ export const handleMulticallArg = async ({
   const encodedFormActions = arg.formActions
     ? handleMulticallFormActions({ appState })
     : [];
+
+  if (arg.type === 'encodeMulticall') {
+    const result = encodeMultiSend([...encodedActions, ...encodedFormActions]);
+
+    if (typeof result !== 'string') {
+      throw new Error('Could not encode generic multicall');
+    }
+    return result;
+  }
 
   const result = encodeMultiAction([...encodedActions, ...encodedFormActions]);
 

--- a/libs/tx-builder/src/utils/multicall.ts
+++ b/libs/tx-builder/src/utils/multicall.ts
@@ -243,7 +243,7 @@ export const handleMulticallArg = async ({
             explorerKeys,
           })
         : 0;
-      console.log('processedOperations', processedOperations);
+
       // Early return if encoded data is passed and args do not need processing
       if (data) {
         return {

--- a/libs/tx-builder/src/utils/multicall.ts
+++ b/libs/tx-builder/src/utils/multicall.ts
@@ -293,6 +293,8 @@ export const handleMulticallArg = async ({
 
   if (arg.type === 'encodeMulticall') {
     const result = encodeMultiSend([...encodedActions, ...encodedFormActions]);
+    console.log('arg.type', arg.type);
+    console.log('result', result);
 
     if (typeof result !== 'string') {
       throw new Error('Could not encode generic multicall');

--- a/libs/utils/src/types/legoTypes.ts
+++ b/libs/utils/src/types/legoTypes.ts
@@ -55,6 +55,11 @@ export type MulticallArg = {
   actions: MulticallAction[];
   formActions?: boolean;
 };
+export type EncodeMulticall = {
+  type: 'encodeMulticall';
+  actions: MulticallAction[];
+  formActions?: boolean;
+};
 export type EncodeCallArg = {
   type: 'encodeCall';
   action: MulticallAction;
@@ -109,6 +114,7 @@ export type ValidArgType =
   | ProposalExpiry
   | StaticArg
   | IPFSPinata
+  | EncodeMulticall
   | ArgEncode;
 
 export type TxStates =


### PR DESCRIPTION
## GitHub Issue

- No issue. Based on an ongoing need in Single DAO apps. 

Discussed adding this to EthDenver tooling scope w/ Sam. 

## Changes

Creates a separate argType that decouples multisend calls from Baal proposals. 

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)


## Important: 

This will not work on its own. Because of the delegateCall guard on the multisend, we may need to make changes on the contract side. 

https://github.com/safe-global/safe-contracts/blob/main/contracts/libraries/MultiSend.sol#L27

## Time Spent

90 mins