### PR TITLE
Use reverse resolution to fetch main ENS name from address

### DIFF
--- a/apps/admin/src/components/MemberProfileAvatar.tsx
+++ b/apps/admin/src/components/MemberProfileAvatar.tsx
@@ -30,7 +30,7 @@ export const MemberProfileAvatar = ({
 
   const fetchMemberProfile = useCallback(
     async (address: string, setter: typeof setMemberProfile) => {
-      const profile = await fetchProfile(address);
+      const profile = await fetchProfile(address, daochain);
       setter(profile);
     },
     []

--- a/apps/admin/src/components/ProposalCardOverview.tsx
+++ b/apps/admin/src/components/ProposalCardOverview.tsx
@@ -7,7 +7,7 @@ import {
   charLimit,
   formatShortDateTimeFromSeconds,
 } from '@daohaus/utils';
-import { Keychain } from '@daohaus/keychain-utils';
+import { Keychain, ValidNetwork } from '@daohaus/keychain-utils';
 
 import { MolochV3Proposal } from '@daohaus/moloch-v3-data';
 import {
@@ -80,7 +80,7 @@ export const ProposalCardOverview = ({
 
   const fetchMemberProfile = useCallback(
     async (address: string, setter: typeof setSubmitterProfile) => {
-      const profile = await fetchProfile(address);
+      const profile = await fetchProfile(address, daochain as ValidNetwork);
       setter(profile);
     },
     []

--- a/apps/admin/src/pages/Member.tsx
+++ b/apps/admin/src/pages/Member.tsx
@@ -33,7 +33,7 @@ import {
   AccountProfile,
 } from '@daohaus/utils';
 
-import { Keychain } from '@daohaus/keychain-utils';
+import { Keychain, ValidNetwork } from '@daohaus/keychain-utils';
 
 import { ButtonRouterLink } from '../components/ButtonRouterLink';
 import { DaoTable } from '../components/DaohausTable';
@@ -126,7 +126,7 @@ export function Member() {
   const fetchMemberProfile = useCallback(
     async (address: string, loadState: typeof setCurrentMemberLoading) => {
       loadState(true);
-      const profile = await fetchProfile(address);
+      const profile = await fetchProfile(address, daochain as ValidNetwork);
       setCurrentProfile(profile);
       loadState(false);
     },

--- a/apps/admin/src/utils/cacheProfile.ts
+++ b/apps/admin/src/utils/cacheProfile.ts
@@ -7,6 +7,7 @@ import {
   getlocalForage,
 } from '@daohaus/utils';
 import { getProfileForAddress } from '@daohaus/profile-data';
+import { ValidNetwork } from '@daohaus/keychain-utils';
 
 export const getProfileStore = async () =>
   (await getlocalForage(CacheStoreName.MEMBERS_PROFILE)) as ArbitraryState;
@@ -60,11 +61,12 @@ export const cacheProfile = async ({
 };
 
 export const fetchProfile = async (
-  address: string
+  address: string,
+  chainId: ValidNetwork
 ): Promise<AccountProfile> => {
   const cachedProfile = await getCachedProfile({ address });
   if (cachedProfile) return cachedProfile;
-  const profile = await getProfileForAddress(address);
+  const profile = await getProfileForAddress(address, chainId);
   cacheProfile({
     address,
     profile,

--- a/apps/admin/src/utils/cacheProfile.ts
+++ b/apps/admin/src/utils/cacheProfile.ts
@@ -7,7 +7,7 @@ import {
   getlocalForage,
 } from '@daohaus/utils';
 import { getProfileForAddress } from '@daohaus/profile-data';
-import { ValidNetwork } from '@daohaus/keychain-utils';
+import { HAUS_NETWORK_DATA, ValidNetwork } from '@daohaus/keychain-utils';
 
 export const getProfileStore = async () =>
   (await getlocalForage(CacheStoreName.MEMBERS_PROFILE)) as ArbitraryState;
@@ -66,7 +66,12 @@ export const fetchProfile = async (
 ): Promise<AccountProfile> => {
   const cachedProfile = await getCachedProfile({ address });
   if (cachedProfile) return cachedProfile;
-  const profile = await getProfileForAddress(address, chainId);
+  // Workaround when poiting to a network where ENS is not deployed
+  const daochain = !['0x1', '0x5'].includes(chainId) ? '0x1' : chainId;
+  const profile = await getProfileForAddress(
+    address,
+    HAUS_NETWORK_DATA[daochain]?.rpc
+  );
   cacheProfile({
     address,
     profile,

--- a/libs/connect-context/src/ConnectContext.tsx
+++ b/libs/connect-context/src/ConnectContext.tsx
@@ -105,9 +105,10 @@ export const ConnectProvider = ({
 
   useEffect(() => {
     let shouldUpdate = true;
-    if (address && isConnected && address !== profile?.address) {
+    if (address && chainId && isConnected && address !== profile?.address) {
       loadProfile({
         address,
+        chainId,
         setProfile,
         setProfileLoading,
         shouldUpdate,
@@ -118,7 +119,7 @@ export const ConnectProvider = ({
     return () => {
       shouldUpdate = false;
     };
-  }, [address, isConnected, networks, lifeCycleFns, profile]);
+  }, [address, chainId, isConnected, networks, lifeCycleFns, profile]);
 
   const connectWallet = useCallback(async () => {
     handleConnectWallet({

--- a/libs/connect-context/src/utils/contextHelpers.ts
+++ b/libs/connect-context/src/utils/contextHelpers.ts
@@ -140,6 +140,7 @@ export const loadProfile = async ({
   setProfileLoading,
   shouldUpdate,
   lifeCycleFns,
+  networks,
 }: {
   address: string;
   chainId: ValidNetwork;
@@ -151,7 +152,12 @@ export const loadProfile = async ({
 }) => {
   try {
     setProfileLoading(true);
-    const profile = await getProfileForAddress(address, chainId);
+    // Workaround when poiting to a network where ENS is not deployed
+    const daochain = !['0x1', '0x5'].includes(chainId) ? '0x1' : chainId;
+    const profile = await getProfileForAddress(
+      address,
+      networks[daochain]?.rpc
+    );
 
     if (profile && shouldUpdate) {
       const displayName =

--- a/libs/connect-context/src/utils/contextHelpers.ts
+++ b/libs/connect-context/src/utils/contextHelpers.ts
@@ -135,12 +135,14 @@ export const loadWallet = async ({
 
 export const loadProfile = async ({
   address,
+  chainId,
   setProfile,
   setProfileLoading,
   shouldUpdate,
   lifeCycleFns,
 }: {
   address: string;
+  chainId: ValidNetwork;
   setProfile: Dispatch<SetStateAction<UserProfile>>;
   setProfileLoading: Dispatch<SetStateAction<boolean>>;
   shouldUpdate: boolean;
@@ -149,7 +151,7 @@ export const loadProfile = async ({
 }) => {
   try {
     setProfileLoading(true);
-    const profile = await getProfileForAddress(address);
+    const profile = await getProfileForAddress(address, chainId);
 
     if (profile && shouldUpdate) {
       const displayName =

--- a/libs/profile-data/src/profile.ts
+++ b/libs/profile-data/src/profile.ts
@@ -1,4 +1,6 @@
+import { providers } from 'ethers';
 import { graphFetchList } from '@daohaus/data-fetch-utils';
+import { HAUS_RPC, ValidNetwork } from '@daohaus/keychain-utils';
 import { AccountProfile } from '@daohaus/utils';
 import {
   ListActiveDomainsDocument,
@@ -14,16 +16,44 @@ import { ENSDomain, LensProfile } from './types';
 import { transformProfile } from './utils';
 
 export const getProfileForAddress = async (
-  address: string
+  address: string,
+  chainId: ValidNetwork
 ): Promise<AccountProfile> => {
-  const ensDomain = await getENSDomain({
-    address,
-  });
+  const reverseEnsRecord = await getENSReverseResolver({ address, chainId });
+  const ensDomain = reverseEnsRecord
+    ? reverseEnsRecord
+    : await getENSDomain({
+        address,
+      });
   const lensProfile = await getLensProfile({
     memberAddress: address,
   } as ListProfileQueryVariables);
 
   return transformProfile({ address, lensProfile, ensDomain });
+};
+
+const getENSReverseResolver = async ({
+  address,
+  chainId,
+}: {
+  address: string;
+  chainId: ValidNetwork;
+}) => {
+  // Workaround when poiting to a network where ENS is not deployed
+  const daochain = !['0x1', '0x5'].includes(chainId) ? '0x1' : chainId; 
+  try {
+    const provider = new providers.JsonRpcProvider(HAUS_RPC[daochain]);
+    const domainName = await provider.lookupAddress(address);
+    if (domainName) {
+      return {
+        domain: {
+          name: domainName,
+        },
+      };
+    }
+  } catch (error) {
+    console.error('Unable to fetch ENS reverse record', error);
+  }
 };
 
 const getENSDomain = async ({

--- a/libs/profile-data/src/profile.ts
+++ b/libs/profile-data/src/profile.ts
@@ -1,6 +1,5 @@
 import { providers } from 'ethers';
 import { graphFetchList } from '@daohaus/data-fetch-utils';
-import { HAUS_RPC, ValidNetwork } from '@daohaus/keychain-utils';
 import { AccountProfile } from '@daohaus/utils';
 import {
   ListActiveDomainsDocument,
@@ -17,9 +16,10 @@ import { transformProfile } from './utils';
 
 export const getProfileForAddress = async (
   address: string,
-  chainId: ValidNetwork
+  rpcUri?: string
 ): Promise<AccountProfile> => {
-  const reverseEnsRecord = await getENSReverseResolver({ address, chainId });
+  const reverseEnsRecord =
+    rpcUri && (await getENSReverseResolver({ address, rpcUri }));
   const ensDomain = reverseEnsRecord
     ? reverseEnsRecord
     : await getENSDomain({
@@ -34,15 +34,13 @@ export const getProfileForAddress = async (
 
 const getENSReverseResolver = async ({
   address,
-  chainId,
+  rpcUri,
 }: {
   address: string;
-  chainId: ValidNetwork;
+  rpcUri: string;
 }) => {
-  // Workaround when poiting to a network where ENS is not deployed
-  const daochain = !['0x1', '0x5'].includes(chainId) ? '0x1' : chainId;
   try {
-    const provider = new providers.JsonRpcProvider(HAUS_RPC[daochain]);
+    const provider = new providers.JsonRpcProvider(rpcUri);
     const domainName = await provider.lookupAddress(address);
     if (domainName) {
       return {

--- a/libs/profile-data/src/profile.ts
+++ b/libs/profile-data/src/profile.ts
@@ -40,7 +40,7 @@ const getENSReverseResolver = async ({
   chainId: ValidNetwork;
 }) => {
   // Workaround when poiting to a network where ENS is not deployed
-  const daochain = !['0x1', '0x5'].includes(chainId) ? '0x1' : chainId; 
+  const daochain = !['0x1', '0x5'].includes(chainId) ? '0x1' : chainId;
   try {
     const provider = new providers.JsonRpcProvider(HAUS_RPC[daochain]);
     const domainName = await provider.lookupAddress(address);

--- a/libs/profile-data/src/types/ens.types.ts
+++ b/libs/profile-data/src/types/ens.types.ts
@@ -1,8 +1,8 @@
 export type ENSDomain =
   | {
-      id: string;
-      registrationDate: string;
-      expiryDate: string;
+      id?: string;
+      registrationDate?: string;
+      expiryDate?: string;
       domain?: {
         name?: string;
       };


### PR DESCRIPTION
## GitHub Issue

Fixes #186 

## Changes

Apparently, it's no that easy to identify the main ENS name from an address using the subgraph. Going through the ENS docs, I find out how it uses [Reverse Resolution](https://docs.ens.domains/dapp-developer-guide/resolving-names#reverse-resolution) using a special purpose domain to set the primary ENS name a.k.a  main reverse record. The recommended approach is to use an `etherjs` provider and call `lookupAddress`, otherwise seems that we need to manually concatenate `.${address}.addr.reverse`, `namehash` it and look for the resolver in the subgraph.

I used the recommended approach to fetch the main ENS record. If not found, it fallbacks to query the subgraph for the first non-expired ens domain registered by an account address.

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
