### PR TITLE
Truncate units display on max tribute button

### DIFF
--- a/apps/admin/src/components/customFields/TributeInput.tsx
+++ b/apps/admin/src/components/customFields/TributeInput.tsx
@@ -1,5 +1,6 @@
 import { LOCAL_ABI } from '@daohaus/abis';
 import {
+  formatValueTo,
   handleErrorMessage,
   isEthAddress,
   ReactSetter,
@@ -177,7 +178,11 @@ export const TributeInput = (
 
   const maxButton = tokenData?.balance && tokenData?.decimals && (
     <Button color="secondary" size="sm" onClick={handleMax} type="button">
-      Max: {toWholeUnits(tokenData?.balance, tokenData?.decimals)}
+      Max:{' '}
+      {formatValueTo({
+        value: toWholeUnits(tokenData?.balance, tokenData?.decimals),
+        decimals: 6,
+      })}
     </Button>
   );
 


### PR DESCRIPTION
## GitHub Issue

None

## Changes

Fixes units being displayed within the max tribute button when a user token balance has a large amount of decimals

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
