### PR TITLE
Enable customs fonts

### DIFF
--- a/apps/admin-new/src/fonts.css
+++ b/apps/admin-new/src/fonts.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;0,900;1,400;1,700&display=swap');

--- a/apps/admin-new/src/main.tsx
+++ b/apps/admin-new/src/main.tsx
@@ -1,9 +1,10 @@
-import { HausThemeProvider } from '@daohaus/ui';
+import { font, HausThemeProvider, ThemeOverrides } from '@daohaus/ui';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { App } from './App';
+import './fonts.css';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -19,10 +20,19 @@ const queryClient = new QueryClient({
   },
 });
 
+const themeOverrides: ThemeOverrides = {
+  font: {
+    family: {
+      ...font.family,
+      body: `'Roboto', sans-serif`,
+    },
+  },
+};
+
 root.render(
   <StrictMode>
     <HashRouter>
-      <HausThemeProvider>
+      <HausThemeProvider themeOverrides={themeOverrides}>
         <QueryClientProvider client={queryClient}>
           <App />
         </QueryClientProvider>

--- a/libs/ui/src/components/atoms/Button/Button.styles.ts
+++ b/libs/ui/src/components/atoms/Button/Button.styles.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { font } from '../../../theme/global/font';
+import { Theme } from '../../../types';
 import { ButtonJustifyContent, ButtonColor } from './Button.types';
 
 export const StyledButton = styled.button<{
@@ -111,7 +112,7 @@ export const StyledButton = styled.button<{
 
   &.link {
     height: auto;
-    font-family: ${font.family.body};
+    font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
     font-weight: ${font.weight.reg};
     font-size: ${font.size.md};
     text-decoration: none;

--- a/libs/ui/src/components/atoms/Input/Input.styles.ts
+++ b/libs/ui/src/components/atoms/Input/Input.styles.ts
@@ -11,7 +11,7 @@ export const BaseInput = styled.input`
   color: ${({ theme }: { theme: Theme }) => theme.rootFontColor};
   font-size: ${field.fontSize};
   font-weight: ${field.fontWeight};
-  font-family: ${field.fontFamily};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   height: 4.8rem;
   line-height: 150%;
   letter-spacing: 1.5px;
@@ -48,7 +48,7 @@ export const BaseInput = styled.input`
   }
 
   &.number {
-    font-family: ${font.family.data};
+    font-family: ${({ theme }: { theme: Theme }) => theme.font.family.data};
     font-weight: ${font.weight.reg};
     letter-spacing: 1px;
   }

--- a/libs/ui/src/components/atoms/Label/Label.styles.ts
+++ b/libs/ui/src/components/atoms/Label/Label.styles.ts
@@ -1,8 +1,9 @@
-import { font } from '../../../theme/global/font';
 import styled from 'styled-components';
+import { font } from '../../../theme/global/font';
+import { Theme } from '../../../types';
 
 export const StyledLabel = styled.label`
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   font-weight: ${font.weight.reg};
   font-size: ${font.size.md};
   color: ${(props) => props.color};

--- a/libs/ui/src/components/atoms/Link/Link.styles.ts
+++ b/libs/ui/src/components/atoms/Link/Link.styles.ts
@@ -9,7 +9,7 @@ export const LinkStyles = css`
   color: ${({ theme }: { theme: Theme }) => theme.primary.step10};
   cursor: pointer;
   display: inline-flex;
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   font-weight: ${font.weight.reg};
   font-size: ${font.size.md};
   text-decoration: none;

--- a/libs/ui/src/components/atoms/Select/Select.styles.ts
+++ b/libs/ui/src/components/atoms/Select/Select.styles.ts
@@ -42,7 +42,7 @@ export const BaseSelect = styled.select`
   display: inline-flex;
   font-size: ${field.fontSize};
   font-weight: ${field.fontWeight};
-  font-family: ${field.fontFamily};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   height: 4.8rem;
   justify-content: space-between;
   line-height: 150%;
@@ -91,7 +91,7 @@ export const BaseSelect = styled.select`
 export const StyledOption = styled.option`
   background-color: ${({ theme }: { theme: Theme }) => theme.secondary.step3};
   color: ${({ theme }: { theme: Theme }) => theme.secondary.step11};
-  font-family: ${field.fontFamily};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   font-size: ${field.fontSize};
   font-weight: ${field.fontWeight};
   height: 4.8rem;

--- a/libs/ui/src/components/atoms/Switch/Switch.styles..ts
+++ b/libs/ui/src/components/atoms/Switch/Switch.styles..ts
@@ -106,7 +106,7 @@ export const LabelContainer = styled.label`
 
 export const StyledLabel = styled.label`
   color: white;
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   font-weight: ${font.weight.reg};
   font-size: ${font.size.md};
 

--- a/libs/ui/src/components/atoms/TextArea/TextArea.styles.ts
+++ b/libs/ui/src/components/atoms/TextArea/TextArea.styles.ts
@@ -10,7 +10,7 @@ export const BaseTextArea = styled.textarea`
   color: ${({ theme }: { theme: Theme }) => theme.rootFontColor};
   font-size: ${field.fontSize};
   font-weight: ${field.fontWeight};
-  font-family: ${field.fontFamily};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   height: 7.688rem;
   max-width: ${field.size.lg};
   height: ${({ height }: { height?: string }) => height || '12rem'};

--- a/libs/ui/src/components/atoms/Typography/Typography.tsx
+++ b/libs/ui/src/components/atoms/Typography/Typography.tsx
@@ -5,13 +5,13 @@ import { Theme } from '../../../types/theming';
 
 ////////////////////PARAGRAPH TEXT////////////////////
 const Par = styled.p`
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   font-weight: ${font.weight.reg};
   color: ${({ theme, color }: { color?: string; theme: Theme }) =>
     color || theme.rootFontColor};
 `;
 const Data = styled.p`
-  font-family: ${font.family.data};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.data};
   font-weight: ${font.weight.reg};
   color: ${(props) => props.color};
   letter-spacing: 1px;
@@ -36,37 +36,37 @@ export const ParXl = styled(Par)`
 export const H6 = styled.h6`
   font-size: ${font.size.md};
   font-weight: ${font.weight.black};
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   color: ${(props) => props.color};
 `;
 export const H5 = styled.h5`
   font-size: ${font.size.lg};
   font-weight: ${font.weight.bold};
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   color: ${(props) => props.color};
 `;
 export const H4 = styled.h4`
   font-size: ${font.size.xl};
   font-weight: ${font.weight.bold};
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   color: ${(props) => props.color};
 `;
 export const H3 = styled.h3`
   font-size: ${font.size.xxl};
   font-weight: ${font.weight.reg};
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   color: ${(props) => props.color};
 `;
 export const H2 = styled.h2`
   font-size: ${font.size.xxxl};
   font-weight: ${font.weight.light};
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   color: ${(props) => props.color};
 `;
 export const H1 = styled.h1`
   font-size: ${font.size.xxxxl};
   font-weight: ${font.weight.light};
-  font-family: ${font.family.body};
+  font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
   color: ${(props) => props.color};
 `;
 ////////////////////DATA TEXT////////////////////

--- a/libs/ui/src/styled.d.ts
+++ b/libs/ui/src/styled.d.ts
@@ -49,6 +49,15 @@ export interface BtnTargets {
   };
 }
 
+export interface DefaultThemeOverrides {
+  font?: {
+    family: {
+      body: string;
+      data: string;
+    };
+  };
+}
+
 type ColorSteps = {
   step1: string;
   step2: string;
@@ -163,6 +172,12 @@ declare module 'styled-components' {
         success: string;
         warning: string;
         error: string;
+      };
+    };
+    font: {
+      family: {
+        body: string;
+        data: string;
       };
     };
   }

--- a/libs/ui/src/styled.ts
+++ b/libs/ui/src/styled.ts
@@ -49,6 +49,15 @@ export interface BtnTargets {
   };
 }
 
+export interface DefaultThemeOverrides {
+  font?: {
+    family: {
+      body: string;
+      data: string;
+    };
+  };
+}
+
 type ColorSteps = {
   step1: string;
   step2: string;
@@ -163,6 +172,12 @@ declare module 'styled-components' {
         success: string;
         warning: string;
         error: string;
+      };
+    };
+    font: {
+      family: {
+        body: string;
+        data: string;
       };
     };
   }

--- a/libs/ui/src/theme/HausThemeContext.tsx
+++ b/libs/ui/src/theme/HausThemeContext.tsx
@@ -5,7 +5,7 @@ import { ReactSetter } from '@daohaus/utils';
 
 import { GlobalStyles } from './global/globalStyles';
 import { defaultDarkTheme, defaultLightTheme } from './theme';
-import { Theme } from '../types/theming';
+import { Theme, ThemeOverrides } from '../types/theming';
 import './global/fonts.css';
 import {
   Toast,
@@ -25,6 +25,7 @@ type ProviderProps = {
   defaultDark?: Theme;
   defaultLight?: Theme;
   startDark?: boolean;
+  themeOverrides?: ThemeOverrides;
 };
 
 export const HausThemeContext = createContext<HausUI>({
@@ -36,21 +37,39 @@ export const HausThemeContext = createContext<HausUI>({
 
 const DEFAULT_TOAST_DURATION = 6000;
 
+const mergeThemeProperties = (theme: Theme, overrides: ThemeOverrides) => ({
+  ...theme,
+  ...overrides,
+});
+
 export const HausThemeProvider = ({
   children,
   defaultDark = defaultDarkTheme,
   defaultLight = defaultLightTheme,
   startDark = true,
+  themeOverrides = {},
 }: ProviderProps) => {
-  const [theme, setTheme] = useState(startDark ? defaultDark : defaultLight);
+  const [theme, setTheme] = useState(
+    mergeThemeProperties(startDark ? defaultDark : defaultLight, themeOverrides)
+  );
   const [toast, setToast] = useState<ToastProps | null>(null);
   useEffect(() => {
-    setTheme(startDark ? defaultDark : defaultLight);
-  }, [startDark, defaultDark, defaultLight]);
+    setTheme(
+      mergeThemeProperties(
+        startDark ? defaultDark : defaultLight,
+        themeOverrides
+      )
+    );
+  }, [startDark, defaultDark, defaultLight, themeOverrides]);
 
   const toggleLightDark = () => {
     setTheme((prevState) =>
-      prevState.themeName === defaultDark.themeName ? defaultLight : defaultDark
+      mergeThemeProperties(
+        prevState.themeName === defaultDark.themeName
+          ? defaultLight
+          : defaultDark,
+        themeOverrides
+      )
     );
   };
 

--- a/libs/ui/src/theme/component/fieldFamily.ts
+++ b/libs/ui/src/theme/component/fieldFamily.ts
@@ -1,7 +1,6 @@
 import { font } from '../global';
 
 export const field = {
-  fontFamily: font.family.body,
   fontWeight: font.weight.reg,
   fontSize: font.size.md,
   size: {

--- a/libs/ui/src/theme/global/globalStyles.ts
+++ b/libs/ui/src/theme/global/globalStyles.ts
@@ -36,7 +36,7 @@ export const GlobalStyles = createGlobalStyle`
   }
 
   body {
-    font-family: ${font.family.body};
+    font-family: ${({ theme }: { theme: Theme }) => theme.font.family.body};
     color: ${({ theme }: { theme: Theme }) => theme.rootFontColor}
   }
 

--- a/libs/ui/src/theme/theme.ts
+++ b/libs/ui/src/theme/theme.ts
@@ -34,6 +34,7 @@ import {
   primaryA,
   secondaryA,
 } from './global/colors';
+import { font } from './global/font';
 
 import {
   primaryDarkBtn,
@@ -85,6 +86,9 @@ export const defaultDarkTheme: Theme = {
       error: dangerDark.step9,
     },
   },
+  font: {
+    family: font.family,
+  },
 };
 
 export const defaultLightTheme: Theme = {
@@ -123,5 +127,8 @@ export const defaultLightTheme: Theme = {
       warning: warning.step9,
       error: danger.step9,
     },
+  },
+  font: {
+    family: font.family,
   },
 };

--- a/libs/ui/src/types/theming.ts
+++ b/libs/ui/src/types/theming.ts
@@ -1,3 +1,6 @@
 import { DefaultTheme } from 'styled-components';
+import { DefaultThemeOverrides } from '../styled';
 
 export type Theme = DefaultTheme;
+
+export type ThemeOverrides = DefaultThemeOverrides;


### PR DESCRIPTION
## GitHub Issue

Closes #170 

## Changes

Update theme context & underlying properties to allow custom fonts per App. Changes introduced in this PR would also enable dApp developers to override other theme properties in the future.

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
