### PR TITLE
Add template arg type to form builder

### DIFF
--- a/libs/tx-builder/src/utils/args.ts
+++ b/libs/tx-builder/src/utils/args.ts
@@ -86,6 +86,21 @@ export const processArg = async ({
   if (arg?.type === 'static') {
     return arg.value;
   }
+  if (arg?.type === 'template') {
+    // appState variables should be enclosed in curly braces e.g. `Send {.formValues.value} ETH`
+    const fragments = arg.value.split(/{|}/g);
+    return fragments
+      .map((f: string) =>
+        f[0] === '.'
+          ? searchArg({
+              appState,
+              searchString: f as StringSearch,
+              shouldThrow: true,
+            })
+          : f
+      )
+      .join('');
+  }
   if (arg?.type === 'singleton') {
     return handleKeychainArg({ chainId, keychain: arg.keychain });
   }

--- a/libs/utils/src/types/legoTypes.ts
+++ b/libs/utils/src/types/legoTypes.ts
@@ -82,6 +82,11 @@ type StaticArg = {
   value: ArgType;
 };
 
+type TemplateArg = {
+  type: 'template';
+  value: string;
+};
+
 type SingletonSearch = {
   type: 'singleton';
   keychain: Keychain;
@@ -113,6 +118,7 @@ export type ValidArgType =
   | EncodeCallArg
   | ProposalExpiry
   | StaticArg
+  | TemplateArg
   | IPFSPinata
   | EncodeMulticall
   | ArgEncode;


### PR DESCRIPTION
## GitHub Issue

Closes #196

## Changes

Add template arg type to form builder so string template params can be defined within a tx lego. Any app state variable should be enclosed in curly braces e.g. 'Send {.formValues.value} ETH'

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
