### PR TITLE
cast dao.proposalOffering to Number for gt comparison

### DIFF
--- a/apps/admin/src/components/customFields/ProposalOffering.tsx
+++ b/apps/admin/src/components/customFields/ProposalOffering.tsx
@@ -25,7 +25,7 @@ export const ProposalOffering = (props: Buildable<{ id?: string }>) => {
   useEffect(() => {
     if (!dao || !id) return;
 
-    if (!connectedMember || dao.sponsorThreshold > connectedMember.shares) {
+    if (!connectedMember || Number(dao.sponsorThreshold) > Number(connectedMember.shares)) {
       setRequiresOffering(true);
       setValue(id, dao.proposalOffering);
       return;

--- a/libs/moloch-v3-fields/src/fields/ProposalOffering.tsx
+++ b/libs/moloch-v3-fields/src/fields/ProposalOffering.tsx
@@ -27,7 +27,7 @@ export const ProposalOffering = (props: Buildable<{ id?: string }>) => {
   useEffect(() => {
     if (!dao || !id) return;
 
-    if (!connectedMember || dao.sponsorThreshold > connectedMember.shares) {
+    if (!connectedMember || Number(dao.sponsorThreshold) > Number(connectedMember.shares)) {
       setRequiresOffering(true);
       setValue(id, dao.proposalOffering);
       return;


### PR DESCRIPTION
## GitHub Issue

Add a link to the GitHub issue.

## Changes

proposalOffering and connectedMember.shares are strings so can not be compared as big numbers

## Packages Added

NA

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
