### PR TITLE
multisend actions: enable custom data + send native token only

### DIFF
--- a/apps/admin/src/components/customFields/MultisendActions.tsx
+++ b/apps/admin/src/components/customFields/MultisendActions.tsx
@@ -190,6 +190,8 @@ const Action = ({
   const abiFieldId = `tx.${actionId}.abi`;
   const valueFieldId = `tx.${actionId}.value`;
   const dataFieldId = `tx.${actionId}.data`;
+  const customDataToggleFieldId = `tx.${actionId}.toggleCustomData`;
+  const customDataFieldId = `tx.${actionId}.customData`;
   const contractMethodFieldId = `tx.${actionId}.contractMethod`;
   // const deletedFlagId = `tx.${actionId}.deleted`; // TODO: Enable `Delete Action Button`
 
@@ -212,14 +214,23 @@ const Action = ({
   const [noArgs, toggleNoArgs] = useState<boolean>(false);
   const [actionError, setActionError] = useState<string>('');
 
-  const [contractAddress, contractAbi, actionValue, actionData, abiMethod] =
-    watch([
-      contractAddressFieldId,
-      abiFieldId,
-      valueFieldId,
-      dataFieldId,
-      contractMethodFieldId,
-    ]);
+  const [
+    contractAddress,
+    contractAbi,
+    actionValue,
+    actionData,
+    customDataToggle,
+    customData,
+    abiMethod,
+  ] = watch([
+    contractAddressFieldId,
+    abiFieldId,
+    valueFieldId,
+    dataFieldId,
+    customDataToggleFieldId,
+    customDataFieldId,
+    contractMethodFieldId,
+  ]);
 
   const values = watch();
 
@@ -420,6 +431,13 @@ const Action = ({
   }, [isEOA]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    if (customDataToggle && customData) {
+      setValue(dataFieldId, customData);
+      setValue(`tx.${actionId}.operation`, 0);
+    }
+  }, [customDataToggle, customData]);
+
+  useEffect(() => {
     if (noArgs) {
       encodeAction({ ...values.tx?.[actionId]?.fields });
     }
@@ -478,14 +496,40 @@ const Action = ({
       },
     },
     {
+      id: `${customDataToggleFieldId}Wrapper`,
+      type: 'switch',
+      label: 'Custom data?',
+      disabled: isEOA,
+      switches: [
+        {
+          id: customDataToggleFieldId,
+          fieldLabel: '',
+          defaultChecked: false,
+        },
+      ],
+    },
+    {
+      id: customDataFieldId,
+      type: 'textarea',
+      label: 'Data (Hex encoded)',
+      hidden: !customDataToggle,
+      placeholder: '0x1234...5678',
+      rules: {
+        required: customDataToggle ? 'Data is required' : false,
+      },
+      defaultValue: '0x',
+    },
+    {
       id: contractMethodFieldId,
       disabled: isEOA,
+      hidden: customDataToggle,
       type: 'select',
       label: 'Contract Function',
       options: methods,
       placeholder: 'Select Function',
       rules: {
-        required: !isEOA ? 'Contract function is required' : false,
+        required:
+          !isEOA && !customDataToggle ? 'Contract function is required' : false,
       },
       defaultValue: selectedMethod?.name,
     },

--- a/libs/moloch-v3-fields/src/fields/MultisendActions.tsx
+++ b/libs/moloch-v3-fields/src/fields/MultisendActions.tsx
@@ -191,6 +191,8 @@ const Action = ({
   const abiFieldId = `tx.${actionId}.abi`;
   const valueFieldId = `tx.${actionId}.value`;
   const dataFieldId = `tx.${actionId}.data`;
+  const customDataToggleFieldId = `tx.${actionId}.toggleCustomData`;
+  const customDataFieldId = `tx.${actionId}.customData`;
   const contractMethodFieldId = `tx.${actionId}.contractMethod`;
   // const deletedFlagId = `tx.${actionId}.deleted`; // TODO: Enable `Delete Action Button`
 
@@ -213,14 +215,23 @@ const Action = ({
   const [noArgs, toggleNoArgs] = useState<boolean>(false);
   const [actionError, setActionError] = useState<string>('');
 
-  const [contractAddress, contractAbi, actionValue, actionData, abiMethod] =
-    watch([
-      contractAddressFieldId,
-      abiFieldId,
-      valueFieldId,
-      dataFieldId,
-      contractMethodFieldId,
-    ]);
+  const [
+    contractAddress,
+    contractAbi,
+    actionValue,
+    actionData,
+    customDataToggle,
+    customData,
+    abiMethod,
+  ] = watch([
+    contractAddressFieldId,
+    abiFieldId,
+    valueFieldId,
+    dataFieldId,
+    customDataToggleFieldId,
+    customDataFieldId,
+    contractMethodFieldId,
+  ]);
 
   const values = watch();
 
@@ -421,6 +432,13 @@ const Action = ({
   }, [isEOA]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    if (customDataToggle && customData) {
+      setValue(dataFieldId, customData);
+      setValue(`tx.${actionId}.operation`, 0);
+    }
+  }, [customDataToggle, customData]);
+
+  useEffect(() => {
     if (noArgs) {
       encodeAction({ ...values.tx?.[actionId]?.fields });
     }
@@ -479,14 +497,40 @@ const Action = ({
       },
     },
     {
+      id: `${customDataToggleFieldId}Wrapper`,
+      type: 'switch',
+      label: 'Custom data?',
+      disabled: isEOA,
+      switches: [
+        {
+          id: customDataToggleFieldId,
+          fieldLabel: '',
+          defaultChecked: false,
+        },
+      ],
+    },
+    {
+      id: customDataFieldId,
+      type: 'textarea',
+      label: 'Data (Hex encoded)',
+      hidden: !customDataToggle,
+      placeholder: '0x1234...5678',
+      rules: {
+        required: customDataToggle ? 'Data is required' : false,
+      },
+      defaultValue: '0x',
+    },
+    {
       id: contractMethodFieldId,
       disabled: isEOA,
+      hidden: customDataToggle,
       type: 'select',
       label: 'Contract Function',
       options: methods,
       placeholder: 'Select Function',
       rules: {
-        required: !isEOA ? 'Contract function is required' : false,
+        required:
+          !isEOA && !customDataToggle ? 'Contract function is required' : false,
       },
       defaultValue: selectedMethod?.name,
     },


### PR DESCRIPTION
## GitHub Issue

None

https://discord.com/channels/709210493549674598/908738422666063892/1113550990994591815

## Changes

Add a customData toggle on multisend action items so the user can specify custom hex data or no data (0x) for sending native tokens only to a contract recipient

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
