### PR TITLE
Fix gasEstimateFromActions to use baal module as entrypoint

### DIFF
--- a/libs/tx-builder/src/utils/multicall.ts
+++ b/libs/tx-builder/src/utils/multicall.ts
@@ -6,7 +6,7 @@ import {
   EncodeCallArg,
   encodeFunction,
   encodeValues,
-  EstmimateGas,
+  EstimateGas,
   EthAddress,
   EncodeMulticall,
   JSONDetailsSearch,
@@ -16,6 +16,7 @@ import {
   TXLego,
 } from '@daohaus/utils';
 import {
+  CONTRACT_KEYCHAINS,
   HAUS_RPC,
   Keychain,
   PinataApiKeys,
@@ -277,17 +278,28 @@ export const handleMulticallArg = async ({
     ? handleMulticallFormActions({ appState })
     : [];
 
-  return [...encodedActions, ...encodedFormActions];
+  // if arg type is multicall wrap all actions on a multiSend
+  return arg.type === 'multicall'
+    ? [
+        {
+          to: CONTRACT_KEYCHAINS.GNOSIS_MULTISEND[chainId],
+          data: encodeMultiAction([...encodedActions, ...encodedFormActions]),
+          value: '0',
+          operation: 1,
+        } as MetaTransaction,
+      ]
+    : [...encodedActions, ...encodedFormActions];
 };
 
 export const gasEstimateFromActions = async ({
   actions,
   chainId,
-  safeId,
+  daoId,
 }: {
   actions: MetaTransaction[];
   chainId: ValidNetwork;
-  safeId: string;
+  daoId: string;
+  safeId: string; // not used at the moment
 }) => {
   const esitmatedGases = await Promise.all(
     actions.map(
@@ -295,7 +307,7 @@ export const gasEstimateFromActions = async ({
         await estimateFunctionalGas({
           chainId: chainId,
           constractAddress: action.to,
-          from: safeId, // from value needs to be the baal safe to esitmate without revert
+          from: daoId, // from value needs to be the safe module (baal) to estimate without revert
           value: BigInt(Number(action.value)),
           data: action.data,
         })
@@ -350,7 +362,7 @@ export const handleGasEstimate = async ({
 }: {
   safeId?: string;
   chainId: ValidNetwork;
-  arg: EstmimateGas;
+  arg: EstimateGas;
   appState: ArbitraryState;
   localABIs?: Record<string, ABI>;
   rpcs: Keychain;
@@ -372,9 +384,13 @@ export const handleGasEstimate = async ({
     pinataApiKeys,
     explorerKeys,
   });
+
+  const { daoId } = appState;
+  const metaTx = actions[0]; // multiSend action
   const gasEstimate = await gasEstimateFromActions({
-    actions,
+    actions: encodeExecFromModule({ safeId, metaTx }),
     chainId,
+    daoId,
     safeId,
   });
 
@@ -388,10 +404,32 @@ export const handleGasEstimate = async ({
     return 0;
   }
 };
+
 export const encodeMultiAction = (rawMulti: MetaTransaction[]) => {
   return encodeFunction(LOCAL_ABI.GNOSIS_MULTISEND, 'multiSend', [
     encodeMultiSend(rawMulti),
   ]);
+};
+
+export const encodeExecFromModule = ({
+  safeId,
+  metaTx, // usually a multiSend encoded action. See `encodeMultiAction`
+}: {
+  safeId: string;
+  metaTx: MetaTransaction;
+}) => {
+  return [
+    {
+      to: safeId,
+      data: encodeFunction(
+        LOCAL_ABI.GNOSIS_MODULE,
+        'execTransactionFromModule',
+        [metaTx.to, metaTx.value, metaTx.data, metaTx.operation]
+      ),
+      value: '0',
+      operation: 0,
+    } as MetaTransaction,
+  ];
 };
 
 export const buildMultiCallTX = ({

--- a/libs/utils/src/types/legoTypes.ts
+++ b/libs/utils/src/types/legoTypes.ts
@@ -64,7 +64,7 @@ export type EncodeCallArg = {
   type: 'encodeCall';
   action: MulticallAction;
 };
-export type EstmimateGas = {
+export type EstimateGas = {
   type: 'estimateGas';
   actions: MulticallAction[];
   bufferPercentage?: number;
@@ -111,7 +111,7 @@ export type IPFSPinata = {
 export type ValidArgType =
   | StringSearch
   | JSONDetailsSearch
-  | EstmimateGas
+  | EstimateGas
   | SingletonSearch
   | NestedArray
   | MulticallArg


### PR DESCRIPTION
## GitHub Issue

#327 

## Changes

- Instead of calling `client.estimateGas` using `from -> safe address`, proposal actions are now wrapped on a `execTransactionFromModule` and called by the baal module. It removes some edge cases where the `estimateGas` was failing.
- `handleGasEstimate` now wraps all actions on a multisend, so `estimateGas` doesn't fail on cases where actions depend on each other in order for the batch tx to succeed.

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
