### PR TITLE
Enable custom gas buffer percentage on tx legos

### DIFF
--- a/libs/tx-builder/src/utils/multicall.ts
+++ b/libs/tx-builder/src/utils/multicall.ts
@@ -379,7 +379,7 @@ export const handleGasEstimate = async ({
   });
 
   if (gasEstimate) {
-    const buffer = arg.bufferPercentage ? `1.${arg.bufferPercentage}` : 1.6;
+    const buffer = arg.bufferPercentage || 1.6;
     return Math.round(Number(gasEstimate) * Number(buffer));
   } else {
     // This happens when the safe vault takes longer to be indexed by the Gnosis API
@@ -400,12 +400,14 @@ export const buildMultiCallTX = ({
   actions,
   JSONDetails = basicDetails,
   formActions = false,
+  gasBufferPercentage,
 }: {
   id: string;
   baalAddress?: StringSearch | Keychain | EthAddress;
   JSONDetails?: JSONDetailsSearch;
   actions: MulticallAction[];
   formActions?: boolean;
+  gasBufferPercentage?: number;
 }): TXLego => {
   return {
     id,
@@ -430,6 +432,7 @@ export const buildMultiCallTX = ({
         type: 'estimateGas',
         actions,
         formActions,
+        bufferPercentage: gasBufferPercentage,
       },
       JSONDetails,
     ],


### PR DESCRIPTION
## GitHub Issue

None

## Changes

`buildMultiCallTX` now has a `gasBufferPercentage` parameter so tx legos can now specify a custom gas buffer percentage to use as a multiplier of the returned estimated gas.

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
