### PR TITLE
adding higher retryCount to see if it resolves intermitent issues wit…

### DIFF
--- a/libs/utils/src/utils/viem.ts
+++ b/libs/utils/src/utils/viem.ts
@@ -9,13 +9,15 @@ import { HttpTransport, http, PublicClient, createPublicClient } from 'viem';
 export const createTransport = ({
   chainId,
   rpcs = HAUS_RPC,
+  retryCount = 5,
 }: {
   chainId: ValidNetwork;
   rpcs: Keychain;
+  retryCount?: number;
 }): HttpTransport => {
   const rpc = rpcs[chainId];
   if (!rpc) return http();
-  return http(rpc);
+  return http(rpc, { retryCount });
 };
 
 export const createViemClient = ({
@@ -25,7 +27,11 @@ export const createViemClient = ({
   chainId: ValidNetwork;
   rpcs?: Keychain;
 }): PublicClient => {
-  const transport = createTransport({ chainId, rpcs });
+  const transport = createTransport({
+    chainId,
+    rpcs,
+  });
+
   return createPublicClient({
     chain: VIEM_CHAINS[chainId],
     transport,


### PR DESCRIPTION
…h missing blocks on goerli adn polygon

## GitHub Issue

https://github.com/HausDAO/monorepo/issues/360
https://github.com/HausDAO/monorepo/issues/339

## Changes

viem has a `retryCount` otpion at the transport level -- by increasing the `retryCount` we can potentially resolve intermittent issues with transaction not found and rpc providers failing before a tx goes through.

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
