### PR TITLE
fixing storybook from typescript upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
   },
   "private": true,
   "resolutions": {
-    // workaround for upgrading typescript to version 5
-    // https://github.com/storybookjs/storybook/issues/21642
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,15 @@
   "license": "MIT",
   "scripts": {
     "postinstall": "husky install",
-    "bumpversion": "node tools/scripts/incrementVersion.js"
+    "bumpversion": "node tools/scripts/incrementVersion.js",
+    "build-storybook": "cross-env NODE_OPTIONS=--openssl-legacy-provider build-storybook"
   },
   "private": true,
+  "resolutions": {
+    // workaround for upgrading typescript to version 5
+    // https://github.com/storybookjs/storybook/issues/21642
+    "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0"
+  },
   "dependencies": {
     "@daohaus/baal-contracts": "^1.2.4",
     "@gnosis.pm/safe-apps-react-sdk": "^4.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5234,17 +5234,17 @@
     unfetch "^4.2.0"
     util-deprecate "^1.0.2"
 
-"@storybook/react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0":
-  version "1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0"
-  resolved "https://registry.yarnpkg.com/@storybook/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0.tgz#3103532ff494fb7dc3cf835f10740ecf6a26c0f9"
-  integrity sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==
+"@storybook/react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0", "@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.cd77847.0":
+  version "1.0.6--canary.9.cd77847.0"
+  resolved "https://registry.yarnpkg.com/@storybook/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.6--canary.9.cd77847.0.tgz#35beed1bd0813569fc8852b372c92069fe74a448"
+  integrity sha512-I4oBYmnUCX5IsrZhg+ST72dubSIV4wdwY+SfqJiJ3NHvDpdb240ZjdHAmjIy/yJh5rh42Fl4jbG8Tr4SzwV53Q==
   dependencies:
     debug "^4.1.1"
     endent "^2.0.1"
     find-cache-dir "^3.3.1"
     flat-cache "^3.0.4"
     micromatch "^4.0.2"
-    react-docgen-typescript "^2.1.1"
+    react-docgen-typescript "^2.2.2"
     tslib "^2.0.0"
 
 "@storybook/react@~6.5.9":
@@ -17921,7 +17921,7 @@ react-base16-styling@^0.6.0:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
-react-docgen-typescript@^2.1.1:
+react-docgen-typescript@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
   integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/monorepo/issues/368

## Changes

used a workaround vs updating storybook to version 7

https://github.com/storybookjs/storybook/issues/21642

## Packages Added

`"@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0"`

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
