### PR TITLE
fix: Renamed tagColor

### DIFF
--- a/libs/ui/src/components/atoms/Tag/Tag.styles.ts
+++ b/libs/ui/src/components/atoms/Tag/Tag.styles.ts
@@ -2,27 +2,27 @@ import styled from 'styled-components';
 
 /* TODO: Component specific border radius ?*/
 export const BaseTag = styled.div<{
-  tagColor: 'blue' | 'green' | 'pink' | 'violet' | 'yellow' | 'red';
-  fontSize?: string;
+  $tagColor: 'blue' | 'green' | 'pink' | 'violet' | 'yellow' | 'red';
+  $fontSize?: string;
 }>`
   display: inline-flex;
   align-items: center;
-  background-color: ${({ theme, tagColor }) => theme[`${tagColor}3`]};
-  border: 1px solid ${({ theme, tagColor }) => theme[`${tagColor}3`]};
+  background-color: ${({ theme, $tagColor }) => theme[`${$tagColor}3`]};
+  border: 1px solid ${({ theme, $tagColor }) => theme[`${$tagColor}3`]};
   border-radius: ${({ theme }) => theme.border.radius};
-  color: ${({ theme, tagColor }) => theme[`${tagColor}11`]};
+  color: ${({ theme, $tagColor }) => theme[`${$tagColor}11`]};
   height: fit-content;
   width: fit-content;
   padding: 0.5rem 0.8rem;
-  font-size: ${({ fontSize }) => fontSize};
+  font-size: ${({ $fontSize }) => $fontSize};
   &:hover {
-    background-color: ${({ theme, tagColor }) => theme[`${tagColor}3`]};
-    border: 1px solid ${({ theme, tagColor }) => theme[`${tagColor}4`]};
+    background-color: ${({ theme, $tagColor }) => theme[`${$tagColor}3`]};
+    border: 1px solid ${({ theme, $tagColor }) => theme[`${$tagColor}4`]};
   }
 
   :focus {
-    background-color: ${({ theme, tagColor }) => theme[`${tagColor}3`]};
-    border: 1px solid ${({ theme, tagColor }) => theme[`${tagColor}5`]};
+    background-color: ${({ theme, $tagColor }) => theme[`${$tagColor}3`]};
+    border: 1px solid ${({ theme, $tagColor }) => theme[`${$tagColor}5`]};
     outline: none;
   }
 
@@ -36,7 +36,7 @@ export const BaseTag = styled.div<{
   svg {
     width: 1.2rem;
     height: 1.2rem;
-    color: ${({ theme, tagColor }) => theme[`${tagColor}11`]};
+    color: ${({ theme, $tagColor }) => theme[`${$tagColor}11`]};
   }
 
   svg.icon-left {

--- a/libs/ui/src/components/atoms/Tag/Tag.tsx
+++ b/libs/ui/src/components/atoms/Tag/Tag.tsx
@@ -15,9 +15,9 @@ export const Tag = ({
   const iconClasses = classNames({ tagColor });
   return (
     <BaseTag
-      tagColor={tagColor || 'green'}
       className={className}
-      fontSize={fontSize}
+      $tagColor={tagColor || 'green'}
+      $fontSize={fontSize}
     >
       {IconLeft && <IconLeft className={`${iconClasses} icon-left`} />}
       {children}


### PR DESCRIPTION
## GitHub Issue
NA

## Changes
Renamed tagColor Prop to $tagColor passed to styled component to prevent it being passed to DOM

## Packages Added
NA

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
