### PR TITLE
fix tx lego builder for sidecar safe proposals

### DIFF
--- a/libs/tx-builder/src/utils/multicall.ts
+++ b/libs/tx-builder/src/utils/multicall.ts
@@ -278,17 +278,7 @@ export const handleMulticallArg = async ({
     ? handleMulticallFormActions({ appState })
     : [];
 
-  // if arg type is multicall wrap all actions on a multiSend
-  return arg.type === 'multicall'
-    ? [
-        {
-          to: CONTRACT_KEYCHAINS.GNOSIS_MULTISEND[chainId],
-          data: encodeMultiAction([...encodedActions, ...encodedFormActions]),
-          value: '0',
-          operation: 1,
-        } as MetaTransaction,
-      ]
-    : [...encodedActions, ...encodedFormActions];
+  return [...encodedActions, ...encodedFormActions];
 };
 
 export const gasEstimateFromActions = async ({
@@ -386,7 +376,13 @@ export const handleGasEstimate = async ({
   });
 
   const { daoId } = appState;
-  const metaTx = actions[0]; // multiSend action
+  // wrap on a multiSend action for simulation
+  const metaTx = {
+    to: CONTRACT_KEYCHAINS.GNOSIS_MULTISEND[chainId],
+    data: encodeMultiAction(actions),
+    value: '0',
+    operation: 1,
+  } as MetaTransaction;
   const gasEstimate = await gasEstimateFromActions({
     actions: encodeExecFromModule({ safeId, metaTx }),
     chainId,


### PR DESCRIPTION
## GitHub Issue

None

## Changes

Fix tx encoding errors when building sidecar safe proposals. This error was introduced in #364 so this PR also considers not to break the tx gas estimate process

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
