### PR TITLE
Fix signTypedMessage requests on WalletConnect proposal form

### DIFF
--- a/apps/admin/src/hook/walletConnect.tsx
+++ b/apps/admin/src/hook/walletConnect.tsx
@@ -1,6 +1,11 @@
 import { useState, useCallback } from 'react';
 import { BigNumberish, BytesLike } from 'ethers';
-import { hashMessage, _TypedDataEncoder } from 'ethers/lib/utils';
+import {
+  hashMessage,
+  isHexString,
+  toUtf8String,
+  _TypedDataEncoder,
+} from 'ethers/lib/utils';
 import { LOCAL_ABI } from '@daohaus/abis';
 import { encodeFunction } from '@daohaus/utils';
 import { CONTRACT_KEYCHAINS, ValidNetwork } from '@daohaus/keychain-utils';
@@ -52,14 +57,37 @@ export const isObjectEIP712TypedData = (
   );
 };
 
+const getDecodedMessage = (message: string): string => {
+  if (isHexString(message)) {
+    // If is a hex string we try to extract a message
+    try {
+      return toUtf8String(message);
+    } catch (e) {
+      // the hex string is not UTF8 encoding so we will return the raw message.
+    }
+  }
+  return message;
+};
+
 export const encodeSafeSignMessage = (
   chainId: ValidNetwork,
   message: string | EIP712TypedData
 ) => {
   const signLibAddress = CONTRACT_KEYCHAINS.GNOSIS_SIGNLIB[chainId];
-  const msgHash = isObjectEIP712TypedData(message)
-    ? _TypedDataEncoder.hash(message.domain, message.types, message.message)
-    : hashMessage(message);
+  const signedTypedMessage = (message: string | EIP712TypedData): string => {
+    if (isObjectEIP712TypedData(message)) {
+      const typesCopy = { ...message.types };
+      // Source: https://github.com/safe-global/safe-wallet-web/blob/dev/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
+      // We need to remove the EIP712Domain type from the types object
+      // Because it's a part of the JSON-RPC payload, but for the `.hash` in ethers.js
+      // The types are not allowed to be recursive, so ever type must either be used by another type, or be
+      // the primary type. And there must only be one type that is not used by any other type.
+      delete typesCopy.EIP712Domain;
+      return _TypedDataEncoder.hash(message.domain, typesCopy, message.message);
+    }
+    return hashMessage(getDecodedMessage(message));
+  };
+  const msgHash = signedTypedMessage(message);
   const data = encodeFunction(LOCAL_ABI.GNOSIS_SIGNLIB, 'signMessage', [
     msgHash,
   ]);


### PR DESCRIPTION
## GitHub Issue

None

## Changes

The following error message is thrown when the dao tries to sign a typed message using the wallet connect proposal form:

```
primary types or unused types: "EIP712Domain", "PermitSingle" (argument="types", value={"EIP712Domain":[{"name":"name","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"PermitSingle":[{"name":"details","type":"PermitDetails"},{"name":"spender","type":"address"},{"name":"sigDeadline","type":"uint256"}],"PermitDetails":[{"name":"token","type":"address"},{"name":"amount","type":"uint160"},{"name":"expiration","type":"uint48"},{"name":"nonce","type":"uint48"}]}, code=INVALID_ARGUMENT, version=hash/5.7.0)
```

This PR patches the intercepted message before signing.

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
