### PR TITLE
Fix invalid bignumber when using admin as a SafeApp

### DIFF
--- a/libs/tx-builder/src/utils/overrides.ts
+++ b/libs/tx-builder/src/utils/overrides.ts
@@ -1,5 +1,12 @@
-import { ABI, ArbitraryState, TXLego, TXOverrides } from '@daohaus/utils';
+import {
+  ABI,
+  ArbitraryState,
+  TXLego,
+  TXOverrides,
+  toBigInt,
+} from '@daohaus/utils';
 import { Keychain, PinataApiKeys, ValidNetwork } from '@daohaus/keychain-utils';
+import { BlockTag } from 'viem';
 
 import { processArg } from './args';
 
@@ -23,21 +30,23 @@ const handleProposalOfferingValue = async ({
   explorerKeys: Keychain;
 }) => {
   if (appState['formValues']?.proposalOffering) {
-    return Number(appState['formValues']?.proposalOffering).toFixed();
+    return BigInt(appState['formValues']?.proposalOffering);
   }
 
   return overrides?.value
-    ? await processArg({
-        arg: overrides.value,
-        chainId,
-        safeId,
-        localABIs,
-        appState,
-        rpcs,
-        pinataApiKeys,
-        explorerKeys,
-      })
-    : '0';
+    ? toBigInt(
+        await processArg({
+          arg: overrides.value,
+          chainId,
+          safeId,
+          localABIs,
+          appState,
+          rpcs,
+          pinataApiKeys,
+          explorerKeys,
+        })
+      )
+    : BigInt(0);
 };
 
 export const processOverrides = async ({
@@ -62,7 +71,10 @@ export const processOverrides = async ({
   const { overrides, staticOverrides } = tx;
 
   if (staticOverrides) {
-    return staticOverrides;
+    return {
+      value: BigInt(0),
+      ...staticOverrides,
+    };
   }
 
   return {
@@ -78,28 +90,32 @@ export const processOverrides = async ({
     }),
     gasLimit:
       overrides?.gasLimit &&
-      (await processArg({
-        arg: overrides.gasLimit,
-        chainId,
-        safeId,
-        localABIs,
-        appState,
-        rpcs,
-        pinataApiKeys,
-        explorerKeys,
-      })),
+      toBigInt(
+        await processArg({
+          arg: overrides.gasLimit,
+          chainId,
+          safeId,
+          localABIs,
+          appState,
+          rpcs,
+          pinataApiKeys,
+          explorerKeys,
+        })
+      ),
     gasPrice:
       overrides?.gasPrice &&
-      (await processArg({
-        arg: overrides.gasPrice,
-        chainId,
-        safeId,
-        localABIs,
-        appState,
-        rpcs,
-        pinataApiKeys,
-        explorerKeys,
-      })),
+      toBigInt(
+        await processArg({
+          arg: overrides.gasPrice,
+          chainId,
+          safeId,
+          localABIs,
+          appState,
+          rpcs,
+          pinataApiKeys,
+          explorerKeys,
+        })
+      ),
     from:
       overrides?.from &&
       (await processArg({
@@ -114,7 +130,7 @@ export const processOverrides = async ({
       })),
     blockTag:
       overrides?.blockTag &&
-      (await processArg({
+      ((await processArg({
         arg: overrides.blockTag,
         chainId,
         safeId,
@@ -123,6 +139,6 @@ export const processOverrides = async ({
         rpcs,
         pinataApiKeys,
         explorerKeys,
-      })),
+      })) as BlockTag),
   };
 };

--- a/libs/tx-builder/src/utils/txBuilderUtils.ts
+++ b/libs/tx-builder/src/utils/txBuilderUtils.ts
@@ -212,7 +212,10 @@ export async function prepareTX(args: {
       abi,
       args: processedArgs,
       functionName: method,
-      value: BigInt(0),
+      value: overrides.value,
+      gas: overrides.gasLimit,
+      maxFeePerGas: overrides.gasPrice,
+      blockTag: overrides.blockTag,
     });
 
     lifeCycleFns?.onRequestSign?.();

--- a/libs/tx-builder/src/utils/txBuilderUtils.ts
+++ b/libs/tx-builder/src/utils/txBuilderUtils.ts
@@ -212,6 +212,7 @@ export async function prepareTX(args: {
       abi,
       args: processedArgs,
       functionName: method,
+      value: BigInt(0),
     });
 
     lifeCycleFns?.onRequestSign?.();

--- a/libs/utils/src/types/legoTypes.ts
+++ b/libs/utils/src/types/legoTypes.ts
@@ -1,8 +1,10 @@
 import { JSXElementConstructor } from 'react';
-import { ValidateField } from '../utils';
+import { BlockTag } from 'viem';
+import { Keychain } from '@daohaus/keychain-utils';
+
 import { ABI, ArgType } from './contract';
 import { EthAddress, RequireOnlyOne } from './general';
-import { Keychain } from '@daohaus/keychain-utils';
+import { ValidateField } from '../utils';
 
 export type LookupType = Record<
   string,
@@ -139,6 +141,14 @@ export type TXOverrides = {
   blockTag?: ValidArgType;
 };
 
+export type TXStaticOverrides = {
+  gasLimit?: bigint;
+  value?: bigint;
+  gasPrice?: bigint;
+  from?: `0x${string}`;
+  blockTag?: BlockTag;
+};
+
 export type TXLegoBase = {
   id: string;
   contract: ContractLego;
@@ -147,7 +157,7 @@ export type TXLegoBase = {
   argCallback?: string;
   staticArgs?: ArgType[];
   overrides?: TXOverrides;
-  staticOverrides?: TXOverrides;
+  staticOverrides?: TXStaticOverrides;
   disablePoll?: boolean;
   customPoll?: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/utils/src/utils/formatting.ts
+++ b/libs/utils/src/utils/formatting.ts
@@ -1,6 +1,6 @@
 import { formatEther } from 'viem';
 
-import { Noun } from '../types';
+import { ArgType, Noun } from '../types';
 
 export const truncateAddress = (addr: string) =>
   `${addr.slice(0, 6)}...${addr.slice(-4)}`;
@@ -10,6 +10,11 @@ export const handlePluralNoun = (noun: Noun, count: number) =>
   count === 1 ? noun.singular : noun.plural;
 export const fromWei = (amt: string): string => {
   return formatEther(BigInt(amt)).toString();
+};
+export const toBigInt = (amt?: ArgType): bigint | undefined => {
+  if (amt) {
+    return BigInt(amt as string | number | boolean | bigint);
+  }
 };
 export const isJSON = (obj: unknown) => {
   try {

--- a/libs/utils/src/utils/gas.ts
+++ b/libs/utils/src/utils/gas.ts
@@ -26,21 +26,21 @@ export const getGasCostEstimate = async (
 export const getProcessingGasLimit = (
   actionGasEstimate: string | number,
   chainId: string
-): string => {
+): bigint => {
   if (chainId === '0xa4b1' || chainId === '0xa') {
-    return (
+    return BigInt(
       Number(actionGasEstimate) > 0
         ? Number(actionGasEstimate) +
-          PROCESS_PROPOSAL_GAS_LIMIT_ADDITION +
-          L2_ADDITIONAL_GAS
+            PROCESS_PROPOSAL_GAS_LIMIT_ADDITION +
+            L2_ADDITIONAL_GAS
         : PROCESS_PROPOSAL_GAS_LIMIT_ADDITION * 3.6 + L2_ADDITIONAL_GAS
-    ).toFixed();
+    );
   }
-  return (
+  return BigInt(
     Number(actionGasEstimate) > 0
       ? Number(actionGasEstimate) + PROCESS_PROPOSAL_GAS_LIMIT_ADDITION
       : PROCESS_PROPOSAL_GAS_LIMIT_ADDITION * 3.6
-  ).toFixed();
+  );
 };
 
 // moved getGasCostEstimate function to utils/ethersFallback.ts


### PR DESCRIPTION
## GitHub Issue

None

## Changes

Solves an issue reported when triggering a tx on the admin app loaded as a Safe App
![image](https://github.com/HausDAO/monorepo/assets/926341/99e9eace-b725-4e3c-be63-5a88b0e3da7f)

It also fixes the tx overrides that weren't used after the wagmi migration.

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
