### PR TITLE
adding retry count to wagmi config

### DIFF
--- a/libs/connect-context/src/Connect.tsx
+++ b/libs/connect-context/src/Connect.tsx
@@ -22,17 +22,21 @@ if (!process.env['NX_WALLET_CONNECT_ID']) {
 export const projectId = process.env['NX_WALLET_CONNECT_ID'];
 
 const chains = Object.values(VIEM_CHAINS);
-const { publicClient } = configureChains(chains, [
-  jsonRpcProvider({
-    rpc: (chain) => {
-      const network = getNetworkById(chain.id);
-      return {
-        http: network?.rpc || '',
-      };
-    },
-  }),
-  w3mProvider({ projectId }),
-]);
+const { publicClient } = configureChains(
+  chains,
+  [
+    jsonRpcProvider({
+      rpc: (chain) => {
+        const network = getNetworkById(chain.id);
+        return {
+          http: network?.rpc || '',
+        };
+      },
+    }),
+    w3mProvider({ projectId }),
+  ],
+  { retryCount: 5 }
+);
 export const wagmiConfig = createConfig({
   autoConnect: true,
   connectors: [

--- a/libs/utils/src/utils/gas.ts
+++ b/libs/utils/src/utils/gas.ts
@@ -9,7 +9,6 @@ export const L2_ADDITIONAL_GAS = 5000000;
 // OPTIMISM challenge - how to display this estimated gas fee like we do on other networks.
 // ethers.js getFeeData returns maxFeePerGas as undefined,  might need to use gasPrice some how, then fetch the L1 amount
 // https://community.optimism.io/docs/developers/build/transaction-fees/#displaying-fees-to-users
-
 export const getGasCostEstimate = async (
   gasLimit: number | string,
   chainId: string


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/monorepo/issues/360

## Changes

wagmi has a different config then when we manually create viem clients [usign `createTransport` with manual `retryCount`](https://github.com/HausDAO/monorepo/blob/develop/libs/utils/src/utils/viem.ts#L12)

https://wagmi.sh/react/providers/configuring-chains#retrycount-optional
adding manual `retryCOunt` to configureChains so wagmi also takes the increased attempts into consideration. -- default is 3 currently

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
