### PR TITLE
bump up default gas buffer multiplier

### DIFF
--- a/libs/tx-builder/src/utils/multicall.ts
+++ b/libs/tx-builder/src/utils/multicall.ts
@@ -391,7 +391,7 @@ export const handleGasEstimate = async ({
   });
 
   if (gasEstimate) {
-    const buffer = arg.bufferPercentage || 1.6;
+    const buffer = arg.bufferPercentage || 2;
     return Math.round(Number(gasEstimate) * Number(buffer));
   } else {
     // This happens when the safe vault takes longer to be indexed by the Gnosis API


### PR DESCRIPTION
## GitHub Issue

Reports of failing transactions due to low gas estimates

## Changes

changed the gas multiplier for our default estimate

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs locally
- [ ] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
