### PR TITLE
remove member check on safes action menu, open to any connected member

### DIFF
--- a/libs/moloch-v3-macro-ui/src/components/SafeCard/SafeActionMenu.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/SafeCard/SafeActionMenu.tsx
@@ -6,9 +6,8 @@ import {
   DropdownTrigger,
   DropdownContent,
 } from '@daohaus/ui';
-import { getNetwork, Keychain } from '@daohaus/keychain-utils';
+import { getNetwork } from '@daohaus/keychain-utils';
 import { SafeActionMenuLink, SafeActionMenuTrigger } from './SafeCard.styles';
-import { useDaoMember } from '@daohaus/moloch-v3-hooks';
 import { useDHConnect } from '@daohaus/connect';
 
 type SafeActionMenuProps = {
@@ -25,22 +24,14 @@ export const SafeActionMenu = ({
   daoId,
 }: SafeActionMenuProps) => {
   const { address } = useDHConnect();
-  const { member } = useDaoMember({
-    daoId,
-    daoChain: daoChain as keyof Keychain,
-    memberAddress: address,
-  });
-
-  const enableActions = useMemo(() => {
-    return member && Number(member.shares) > 0;
-  }, [member]);
 
   const networkData = useMemo(() => {
     if (!daoChain) return null;
     return getNetwork(daoChain);
   }, [daoChain]);
 
-  if (!enableActions) return null;
+  // must be connected to view action menu
+  if (!address) return null;
 
   return (
     <DropdownMenu>


### PR DESCRIPTION
## GitHub Issue

fixes #357 

## Changes

Allow any connected wallet to access the Safe action menu. Not just share holding members

## Packages Added

NA

## Checks

Before making your PR, please check the following:

- [ X] Critical lint errors are resolved
- [ X] App runs locally
- [ X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
