### PR TITLE
Fix decoding actions with array params

### DIFF
--- a/libs/moloch-v3-macro-ui/src/utils/proposalDetailsHelpers.ts
+++ b/libs/moloch-v3-macro-ui/src/utils/proposalDetailsHelpers.ts
@@ -48,12 +48,20 @@ const getValueFromMintOrTransferAction = (
     return 'decoding error';
   }
 
-  const value = Array.isArray(actionData.params[1].value)
-    ? (actionData.params[1].value[0] as bigint)
-    : (actionData.params[1].value as bigint);
+  const value = actionData.params[1].type.endsWith('[]')
+    ? actionData.params[1].value
+        .toString()
+        .split(',')
+        .map((v) => BigInt(v))
+    : [BigInt(actionData.params[1].value.toString())];
 
   return formatValueTo({
-    value: toWholeUnits(value.toString(), decimals),
+    value: toWholeUnits(
+      value
+        .reduce((val: bigint, accValue: bigint) => accValue + val, BigInt(0))
+        .toString(),
+      decimals
+    ),
     decimals: 2,
     format: 'numberShort',
   });

--- a/libs/tx-builder/src/utils/deepDecoding.ts
+++ b/libs/tx-builder/src/utils/deepDecoding.ts
@@ -157,7 +157,11 @@ const decodeMethod = (options: {
   const inputsWithValues = (inputs as any[]).map((input, index) => ({
     name: input.name,
     type: input.type,
-    value: result.args?.[index]?.toString() || '0x',
+    value: Array.isArray(result.args?.[index])
+      ? (result.args?.[index] as Array<any>).length
+        ? (result.args?.[index] as Array<any>).toString()
+        : '[]'
+      : result.args?.[index]?.toString() || '0x',
   }));
 
   return {


### PR DESCRIPTION
## GitHub Issue

None

## Changes

This PR fixes the following display bugs found in ProposalDetails:

- When a proposal mint/transfer tokens to multiple recipients, it should sum up the value arrays in `getValueFromMintOrTransferAction`. Current implementation was throwing an exception.
- When a proposal decoded action has empty parameters of type array, it should display `[]` instead of `0x`.

Example proposal that display both issues can be found [here](https://admin.daohaus.fun/#/molochV3/0x5/0x52ccffa85a7d5ce76a343edca9d84acb3f191733/proposal/4)

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
