### PR TITLE
Markdown Editor & Preview respect outer container & responsive;

### DIFF
--- a/libs/moloch-v3-fields/src/fields/MarkdownField.tsx
+++ b/libs/moloch-v3-fields/src/fields/MarkdownField.tsx
@@ -7,8 +7,10 @@ import {
   DialogContent,
   Field,
   Label,
+  Card,
   WrappedTextArea,
 } from '@daohaus/ui';
+
 import { useFormContext } from 'react-hook-form';
 import { BiPencil } from 'react-icons/bi';
 import { MdFullscreen, MdFullscreenExit, MdPreview } from 'react-icons/md';
@@ -38,8 +40,6 @@ const MarkDownContainer = styled.div`
 
 const DialogMarkDownContainer = styled.div`
   height: 50rem;
-  max-width: 100rem;
-  min-width: 50rem;
   overflow-y: scroll;
   padding: 10px;
   margin-bottom: 5rem;
@@ -64,8 +64,12 @@ const LabelContainer = styled(Label)`
 
 const DialogWrappedTextArea = styled(WrappedTextArea)`
   height: 50rem;
-  max-width: 100rem;
-  min-width: 70rem;
+  overflow-y: scroll;
+  padding: 10px;
+  margin-bottom: 5rem;
+  border-radius: 5px;
+  font-size: 1.5rem;
+  font-family: inherit;
 `;
 
 const DialogButtonWrapper = styled.div`
@@ -73,6 +77,12 @@ const DialogButtonWrapper = styled.div`
   flex-direction: row;
   justify-content: right;
   margin-bottom: -2rem;
+`;
+
+const ContentWrapper = styled(Card)`
+  border: none;
+  min-width: 50vw;
+  max-width: 90vw;
 `;
 
 export const MarkdownField = (props: Buildable<Field>) => {
@@ -132,18 +142,20 @@ export const MarkdownField = (props: Buildable<Field>) => {
                 <MdPreview />
               </Button>
             </DialogButtonWrapper>
-            {edit ? (
-              <DialogWrappedTextArea {...props} />
-            ) : (
-              <>
-                <LabelContainer>
-                  <Label>Preview</Label>
-                </LabelContainer>
-                <DialogMarkDownContainer>
-                  <ReactMarkdown>{value}</ReactMarkdown>
-                </DialogMarkDownContainer>
-              </>
-            )}
+            <ContentWrapper>
+              {edit ? (
+                <DialogWrappedTextArea {...props} />
+              ) : (
+                <>
+                  <LabelContainer>
+                    <Label>Preview</Label>
+                  </LabelContainer>
+                  <DialogMarkDownContainer>
+                    <ReactMarkdown>{value}</ReactMarkdown>
+                  </DialogMarkDownContainer>
+                </>
+              )}
+            </ContentWrapper>
           </DialogContent>
         </Dialog>
       </TabsContainer>


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/monorepo/issues/440

## Changes
1. Added a ContentWrapper around the Dialog Content
2. DialogMarkdown Editor & Preview mode now respect that outer content
3. ContentWrapper utilises viewport width to be responsive

![Screenshot 2023-11-06 at 5 43 31 PM](https://github.com/HausDAO/monorepo/assets/82053242/fa8e5b0e-3c2d-4c28-8630-1d02cd8e5a39)
![Screenshot 2023-11-06 at 5 44 07 PM](https://github.com/HausDAO/monorepo/assets/82053242/7b85c767-37c7-422b-9716-19e25368e984)
![Screenshot 2023-11-06 at 5 44 12 PM](https://github.com/HausDAO/monorepo/assets/82053242/181d89bb-37e0-4af3-b109-7860e9d4cd9f)



## Packages Added

none

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
