### PR TITLE
better gas estimation by incorporating estimated overhead for action

### DIFF
--- a/libs/tx-builder/src/utils/constants.ts
+++ b/libs/tx-builder/src/utils/constants.ts
@@ -4,7 +4,7 @@ import { LOCAL_ABI } from '@daohaus/abis';
 export const EXPIRY = '.proposalExpiry';
 export const FORM = '.formValues';
 export const CURRENT_DAO = '.daoId';
-export const gasBufferMultiplier = 5;
+export const gasBufferMultiplier = 1.2; // buffers baalgas estimate
 export const BaalContractBase = {
   type: 'local',
   contractName: 'Baal',

--- a/libs/tx-builder/src/utils/multicall.ts
+++ b/libs/tx-builder/src/utils/multicall.ts
@@ -305,7 +305,7 @@ export const gasEstimateFromActions = async ({
           contractAddress: action.to,
           from: daoId, // from value needs to be the safe module (baal) to estimate without revert
           value: BigInt(Number(action.value)),
-          data: action.data
+          data: action.data,
         })
     )
   );
@@ -316,10 +316,9 @@ export const gasEstimateFromActions = async ({
     0
   );
 
-
   // extra gas overhead when calling the dao from the baal safe
   const baalOnlyGas = actionsCount * ACTION_GAS_LIMIT_ADDITION;
-
+  console.log('baalOnlyGas addtition', baalOnlyGas);
   console.log('totalGasEstimate', totalGasEstimate);
 
   return (totalGasEstimate || 0) + baalOnlyGas;

--- a/libs/utils/src/constants/proposals.ts
+++ b/libs/utils/src/constants/proposals.ts
@@ -105,8 +105,12 @@ export const PROPOSAL_FILTERS: Record<string, string> = {
   failed: 'Defeated',
   expired: 'Expired',
 };
-
-export const GAS_BUFFER_MULTIPLIER = 5;
+// Processing gas estimate buffer
+export const GAS_BUFFER_MULTIPLIER = 2;
 // Adding to the gas limit to account for cost of processProposal
 export const PROCESS_PROPOSAL_GAS_LIMIT_ADDITION = 150000;
+// Adding to the gas limit to account for cost of each action
+export const ACTION_GAS_LIMIT_ADDITION = 150000; 
+
 export const L2_ADDITIONAL_GAS = 5000000;
+

--- a/libs/utils/src/constants/proposals.ts
+++ b/libs/utils/src/constants/proposals.ts
@@ -110,7 +110,6 @@ export const GAS_BUFFER_MULTIPLIER = 2;
 // Adding to the gas limit to account for cost of processProposal
 export const PROCESS_PROPOSAL_GAS_LIMIT_ADDITION = 150000;
 // Adding to the gas limit to account for cost of each action
-export const ACTION_GAS_LIMIT_ADDITION = 150000; 
+export const ACTION_GAS_LIMIT_ADDITION = 150000;
 
 export const L2_ADDITIONAL_GAS = 5000000;
-

--- a/libs/utils/src/utils/gas.ts
+++ b/libs/utils/src/utils/gas.ts
@@ -16,7 +16,6 @@ export const getGasCostEstimate = async (
 ): Promise<number | undefined> => {
   const feeDataNew = await fetchFeeData({ chainId: chainId as ValidNetwork });
 
-  // console.log('feeDataNew', feeDataNew);
   return (
     Number(getProcessingGasLimit(gasLimit, chainId)) *
     Number(feeDataNew.maxFeePerGas || 0)

--- a/libs/utils/src/utils/gas.ts
+++ b/libs/utils/src/utils/gas.ts
@@ -16,7 +16,7 @@ export const getGasCostEstimate = async (
 ): Promise<number | undefined> => {
   const feeDataNew = await fetchFeeData({ chainId: chainId as ValidNetwork });
 
-  console.log('feeDataNew', feeDataNew);
+  // console.log('feeDataNew', feeDataNew);
   return (
     Number(getProcessingGasLimit(gasLimit, chainId)) *
     Number(feeDataNew.maxFeePerGas || 0)


### PR DESCRIPTION


## GitHub Issue
Bad gas estimates on multicall
more on #422 

## Changes

adding a gas buffer on every multicall action to account for extra overhead

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [ X] Critical lint errors are resolved
- [ X] App runs locally
- [ X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
