### PR TITLE
Fix funding proposal tx lego

### DIFF
--- a/libs/moloch-v3-legos/src/tx.ts
+++ b/libs/moloch-v3-legos/src/tx.ts
@@ -254,7 +254,8 @@ export const TX: Record<string, TXLego> = {
         value: '.formValues.paymentAmount',
         data: {
           type: 'static',
-          value: ENCODED_0X0_DATA,
+          // value: ENCODED_0X0_DATA,
+          value: '0x',
         },
       },
     ],

--- a/libs/moloch-v3-legos/src/tx.ts
+++ b/libs/moloch-v3-legos/src/tx.ts
@@ -3,7 +3,6 @@ import {
   NestedArray,
   POSTER_TAGS,
   TABULA_TAGS,
-  ENCODED_0X0_DATA,
   TXLego,
   ValidArgType,
   TXLegoBase,
@@ -254,7 +253,6 @@ export const TX: Record<string, TXLego> = {
         value: '.formValues.paymentAmount',
         data: {
           type: 'static',
-          // value: ENCODED_0X0_DATA,
           value: '0x',
         },
       },
@@ -308,7 +306,6 @@ export const TX: Record<string, TXLego> = {
                       value: '.formValues.paymentAmount',
                       data: {
                         type: 'static',
-                        // value: ENCODED_0X0_DATA,
                         value: '0x',
                       },
                     },


### PR DESCRIPTION
## GitHub Issue

[Reported issue](https://discord.com/channels/684227450204323876/1162312159951335475/1181449676596203540)

## Changes

Fix funding proposal tx lego to set tx calldata to `0x` instead of `ENCODED_0X0_DATA`

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
