### PR TITLE
Fix issue when external apps request WC proposal to estimate gas

### DIFF
--- a/libs/moloch-v3-fields/src/utils/walletConnectV2.tsx
+++ b/libs/moloch-v3-fields/src/utils/walletConnectV2.tsx
@@ -215,6 +215,18 @@ const useWalletConnectV2 = (): useWalletConnectType => {
               });
               break;
             }
+            case 'eth_estimateGas': {
+              // notice: we don't require to estimate gas for the individual contract call to build the proposal calldata
+              await web3wallet.respondSessionRequest({
+                topic,
+                response: {
+                  id,
+                  jsonrpc: '2.0',
+                  result: '0x0', // notice: respond zero gas by default
+                },
+              });
+              break;
+            }
             default: {
               const errorMsg = 'Tx type not supported';
               setError(errorMsg);


### PR DESCRIPTION
## GitHub Issue

None

## Changes

The `Tx type not supported` error was [reported](https://discord.com/channels/709210493549674598/1082758136093478932/1209965126539550861) when trying to use the WalletConnect proposal to catch a transaction from the Superfluid dApp. This happens as the app requests the wallet provider to estimate gas for the individual action before submitting the tx payload. In the case of the WC proposal this isn't required so it's fine to return zero

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
