### PR TITLE
Fix: Long text breaks out of card

### DIFF
--- a/libs/moloch-v3-macro-ui/src/components/ProposalCard/ProposalCardOverview.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/ProposalCard/ProposalCardOverview.tsx
@@ -35,6 +35,7 @@ const OverviewBox = styled.div<{ $allowLinks?: boolean }>`
   }
   .description {
     margin-bottom: auto;
+    word-break: break-word;
   }
   @media ${widthQuery.md} {
     .description {


### PR DESCRIPTION
## GitHub Issue

[Add a link to the GitHub issue.](https://github.com/HausDAO/monorepo/issues/451)

## Changes

Added word break for long text so links and long strings will wrap instead of breaking out of the card

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs locally
- [x] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
