### PR TITLE
Fix/remove safe api usd balances

### DIFF
--- a/libs/moloch-v3-data/src/daos.ts
+++ b/libs/moloch-v3-data/src/daos.ts
@@ -88,7 +88,7 @@ export const findDao = async ({
 
           return {
             ...vault,
-            fiatTotal: vaultResMatch?.data?.fiatTotal,
+            // fiatTotal: vaultResMatch?.data?.fiatTotal,
             tokenBalances: vaultResMatch?.data?.tokenBalances,
           };
         });
@@ -99,10 +99,10 @@ export const findDao = async ({
               ...daoRes.data.dao,
               ...addDaoProfileFields(daoRes.data.dao),
               vaults: hydratedVaults,
-              fiatTotal: tokenData.reduce((sum, vault) => {
-                sum += Number(vault.data?.fiatTotal);
-                return sum;
-              }, 0),
+              // fiatTotal: tokenData.reduce((sum, vault) => {
+              //   sum += Number(vault.data?.fiatTotal);
+              //   return sum;
+              // }, 0),
             },
           },
         };

--- a/libs/moloch-v3-data/src/vaults.ts
+++ b/libs/moloch-v3-data/src/vaults.ts
@@ -16,6 +16,7 @@ export const listTokenBalances = async ({
   safeAddress: string;
 }): Promise<IFindQueryResult<DaoTokenBalances>> => {
   const url = ENDPOINTS['GNOSIS_API'][networkId];
+
   if (!url) {
     return {
       error: formatFetchError({ type: 'INVALID_NETWORK_ERROR' }),
@@ -24,7 +25,9 @@ export const listTokenBalances = async ({
 
   try {
     const res = await fetch.get<TokenBalance[]>(
-      `${url}/safes/${getAddress(safeAddress)}/balances/usd/`
+      // `${url}/safes/${getAddress(safeAddress)}/balances/usd/` // dead link
+      `${url}/safes/${getAddress(safeAddress)}/balances/`
+
     );
 
     return { data: transformTokenBalances(res, safeAddress) };

--- a/libs/moloch-v3-data/src/vaults.ts
+++ b/libs/moloch-v3-data/src/vaults.ts
@@ -27,7 +27,6 @@ export const listTokenBalances = async ({
     const res = await fetch.get<TokenBalance[]>(
       // `${url}/safes/${getAddress(safeAddress)}/balances/usd/` // dead link
       `${url}/safes/${getAddress(safeAddress)}/balances/`
-
     );
 
     return { data: transformTokenBalances(res, safeAddress) };

--- a/libs/moloch-v3-fields/src/fields/RagequitTokenList.tsx
+++ b/libs/moloch-v3-fields/src/fields/RagequitTokenList.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import {
   formatValueTo,
   memberTokenBalanceShare,
-  memberUsdValueShare,
+  // memberUsdValueShare,
   NETWORK_TOKEN_ETH_ADDRESS,
 } from '@daohaus/utils';
 import { getNetwork } from '@daohaus/keychain-utils';
@@ -158,10 +158,10 @@ export const RagequitTokenList = (props: Buildable<Field>) => {
 
           return acc;
         },
-        { 
-          tokenCheckboxes: [], 
-          amounts: [], 
-          // usdValue: [] 
+        {
+          tokenCheckboxes: [],
+          amounts: [],
+          // usdValue: []
         }
       );
   }, [

--- a/libs/moloch-v3-fields/src/fields/RagequitTokenList.tsx
+++ b/libs/moloch-v3-fields/src/fields/RagequitTokenList.tsx
@@ -48,7 +48,7 @@ const DataColumn = styled(Column)`
 type TokenTable = {
   tokenCheckboxes: CheckboxProps[];
   amounts: React.ReactNode[];
-  usdValue: React.ReactNode[];
+  // usdValue: React.ReactNode[];
 };
 
 export const RagequitTokenList = (props: Buildable<Field>) => {
@@ -139,26 +139,30 @@ export const RagequitTokenList = (props: Buildable<Field>) => {
             </DataSm>,
           ];
 
-          acc.usdValue = [
-            ...acc.usdValue,
-            <DataSm key={token.tokenAddress}>
-              {formatValueTo({
-                value: memberUsdValueShare(
-                  token.fiatBalance,
-                  dao.totalShares || 0,
-                  dao.totalLoot || 0,
-                  sharesToBurn || 0,
-                  lootToBurn || 0
-                ),
-                decimals: 2,
-                format: 'currency',
-              })}
-            </DataSm>,
-          ];
+          // acc.usdValue = [
+          //   ...acc.usdValue,
+          //   <DataSm key={token.tokenAddress}>
+          //     {formatValueTo({
+          //       value: memberUsdValueShare(
+          //         token.fiatBalance,
+          //         dao.totalShares || 0,
+          //         dao.totalLoot || 0,
+          //         sharesToBurn || 0,
+          //         lootToBurn || 0
+          //       ),
+          //       decimals: 2,
+          //       format: 'currency',
+          //     })}
+          //   </DataSm>,
+          // ];
 
           return acc;
         },
-        { tokenCheckboxes: [], amounts: [], usdValue: [] }
+        { 
+          tokenCheckboxes: [], 
+          amounts: [], 
+          // usdValue: [] 
+        }
       );
   }, [
     dao,
@@ -210,9 +214,9 @@ export const RagequitTokenList = (props: Buildable<Field>) => {
         <Column>
           <ParSm>Amount</ParSm>
         </Column>
-        <Column>
+        {/* <Column>
           <ParSm>USD Value</ParSm>
-        </Column>
+        </Column> */}
       </TokenListContainer>
       <TokenListContainer>
         <Column>
@@ -223,7 +227,7 @@ export const RagequitTokenList = (props: Buildable<Field>) => {
           />
         </Column>
         <DataColumn>{tokenTable.amounts}</DataColumn>
-        <DataColumn>{tokenTable.usdValue}</DataColumn>
+        {/* <DataColumn>{tokenTable.usdValue}</DataColumn> */}
       </TokenListContainer>
     </>
   );

--- a/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberProfileCard.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberProfileCard.tsx
@@ -1,14 +1,16 @@
 import { ValidNetwork } from '@daohaus/keychain-utils';
 import { MolochV3Member } from '@daohaus/moloch-v3-data';
 import { useDaoData, useProfile } from '@daohaus/moloch-v3-hooks';
-import { DataIndicator, ParLg, Loading } from '@daohaus/ui';
-import { formatValueTo, memberUsdValueShare } from '@daohaus/utils';
+import { 
+  // DataIndicator, 
+  ParLg, Loading } from '@daohaus/ui';
+// import { formatValueTo, memberUsdValueShare } from '@daohaus/utils';
 
 import {
   AlertContainer,
   LoadingContainer,
   MProfileCard,
-  ValueRow,
+  // ValueRow,
 } from './MemberProfileCard.styles';
 import { MemberProfile } from './MemberProfile';
 import { MemberTokens } from './MemberTokens';
@@ -64,7 +66,7 @@ export const MemberProfileCard = ({
             allowLinks={allowLinks}
             allowMemberMenu={allowMemberMenu}
           />
-          <ValueRow>
+          {/* <ValueRow>
             <DataIndicator
               label="Total Exit Amount"
               data={formatValueTo({
@@ -79,7 +81,7 @@ export const MemberProfileCard = ({
                 format: 'currency',
               })}
             />
-          </ValueRow>
+          </ValueRow> */}
           <MemberTokens daoChain={daoChain} dao={dao} member={member} />
         </>
       )}

--- a/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberTokens.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberTokens.tsx
@@ -21,7 +21,7 @@ type TokenTableType = {
     name: string | undefined;
   };
   balance: string;
-  fiatBalance: string;
+  // fiatBalance: string;
 };
 
 type MemberTokensProps = {
@@ -53,17 +53,17 @@ export const MemberTokens = ({ daoChain, dao, member }: MemberTokensProps) => {
               address: bal.tokenAddress || NETWORK_TOKEN_ETH_ADDRESS,
               name: charLimit(bal.token?.name, 21),
             },
-            fiatBalance: formatValueTo({
-              value: memberUsdValueShare(
-                bal.fiatBalance,
-                dao.totalShares || 0,
-                dao.totalLoot || 0,
-                member.shares || 0,
-                member.loot || 0
-              ),
-              decimals: 2,
-              format: 'currency',
-            }),
+            // fiatBalance: formatValueTo({
+            //   value: memberUsdValueShare(
+            //     bal.fiatBalance,
+            //     dao.totalShares || 0,
+            //     dao.totalLoot || 0,
+            //     member.shares || 0,
+            //     member.loot || 0
+            //   ),
+            //   decimals: 2,
+            //   format: 'currency',
+            // }),
             balance: formatValueTo({
               value: memberTokenBalanceShare(
                 bal.balance,
@@ -108,15 +108,15 @@ export const MemberTokens = ({ daoChain, dao, member }: MemberTokensProps) => {
           return <div>{value}</div>;
         },
       },
-      {
-        Header: () => {
-          return <div>USD Value</div>;
-        },
-        accessor: 'fiatBalance',
-        Cell: ({ value }: { value: string }) => {
-          return <div>{value}</div>;
-        },
-      },
+      // {
+      //   Header: () => {
+      //     return <div>USD Value</div>;
+      //   },
+      //   accessor: 'fiatBalance',
+      //   Cell: ({ value }: { value: string }) => {
+      //     return <div>{value}</div>;
+      //   },
+      // },
     ],
     [daoChain, networks]
   );

--- a/libs/moloch-v3-macro-ui/src/components/SafeCard/SafeCard.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/SafeCard/SafeCard.tsx
@@ -78,14 +78,14 @@ export const SafeCard = ({
           </div>
         </SafeCardHeader>
         <DataGrid>
-          <DataIndicator
+          {/* <DataIndicator
             label="Balance"
             data={formatValueTo({
               value: safe.fiatTotal,
               decimals: 2,
               format: 'currencyShort',
             })}
-          />
+          /> */}
           <DataIndicator label="Tokens" data={safe.tokenBalances.length} />
         </DataGrid>
       </SafeOverviewCard>


### PR DESCRIPTION
## GitHub Issue

White screen on any pages that use Safe api for usd balances

## Changes

Temporary fix: comment out all use of usd balances that are retrieved from Safe Api. We should probably remove the API dep all together because it was mainly being used for these usd values

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
