### PR TITLE
Fix/remove safe api usd balances

### DIFF
--- a/apps/admin/src/components/DaoCard.tsx
+++ b/apps/admin/src/components/DaoCard.tsx
@@ -56,7 +56,6 @@ export const DaoCard = ({
   dao,
   daoAvatarImg,
   activeMemberCount,
-  fiatTotal,
   activeProposalCount,
   totalProposalCount,
   votingPower,

--- a/apps/admin/src/components/DaoTable.tsx
+++ b/apps/admin/src/components/DaoTable.tsx
@@ -76,7 +76,6 @@ export const DaoTable = ({ daoData }: IDaoTableData) => {
           networkId: dao.networkId,
         },
         activeProposalCount: dao.activeProposalCount,
-        fiatTotal: dao.fiatTotal,
         activeMemberCount: dao.activeMemberCount,
         votingPower: dao.votingPower,
         networkId: dao.networkId,
@@ -135,19 +134,6 @@ export const DaoTable = ({ daoData }: IDaoTableData) => {
           return (
             <Highlight>
               {readableNumbers.toNumberShort({ value, decimals: 1 })}
-            </Highlight>
-          );
-        },
-      },
-      {
-        Header: 'Vaults',
-        accessor: 'fiatTotal',
-        Cell: ({ value }: { value?: number }) => {
-          return (
-            <Highlight>
-              {value != null
-                ? readableNumbers.toDollars({ value, separator: ' ' })
-                : '--'}
             </Highlight>
           );
         },

--- a/libs/moloch-v3-data/src/daos.ts
+++ b/libs/moloch-v3-data/src/daos.ts
@@ -88,7 +88,6 @@ export const findDao = async ({
 
           return {
             ...vault,
-            // fiatTotal: vaultResMatch?.data?.fiatTotal,
             tokenBalances: vaultResMatch?.data?.tokenBalances,
           };
         });
@@ -99,10 +98,6 @@ export const findDao = async ({
               ...daoRes.data.dao,
               ...addDaoProfileFields(daoRes.data.dao),
               vaults: hydratedVaults,
-              // fiatTotal: tokenData.reduce((sum, vault) => {
-              //   sum += Number(vault.data?.fiatTotal);
-              //   return sum;
-              // }, 0),
             },
           },
         };

--- a/libs/moloch-v3-data/src/types/dao.types.ts
+++ b/libs/moloch-v3-data/src/types/dao.types.ts
@@ -19,7 +19,6 @@ type DaoWithProfileQuery = {
   dao: DaoWithProfile | undefined;
 };
 export type DaoSafe = DaoWithProfile['vaults'][number] & {
-  fiatTotal: number;
   tokenBalances: TokenBalance[];
 };
 type MolochV3DaoQuery = {
@@ -27,7 +26,6 @@ type MolochV3DaoQuery = {
 };
 export type MolochV3Dao = Omit<DaoWithProfile, 'vaults'> & {
   vaults: DaoSafe[];
-  fiatTotal: number;
 };
 export type FindDaoQueryRes =
   | DaoWithProfileQuery

--- a/libs/moloch-v3-data/src/utils/transformers.ts
+++ b/libs/moloch-v3-data/src/utils/transformers.ts
@@ -29,15 +29,7 @@ export const transformTokenBalances = (
   tokenBalanceRes: TokenBalance[],
   safeAddress: string
 ): DaoTokenBalances => {
-  const fiatTotal = tokenBalanceRes.reduce(
-    (sum: number, balance: TokenBalance): number => {
-      sum += Number(balance.fiatBalance);
-      return sum;
-    },
-    0
-  );
-
-  return { safeAddress, tokenBalances: tokenBalanceRes, fiatTotal };
+  return { safeAddress, tokenBalances: tokenBalanceRes };
 };
 
 export const transformMembershipList = (

--- a/libs/moloch-v3-data/src/vaults.ts
+++ b/libs/moloch-v3-data/src/vaults.ts
@@ -25,7 +25,6 @@ export const listTokenBalances = async ({
 
   try {
     const res = await fetch.get<TokenBalance[]>(
-      // `${url}/safes/${getAddress(safeAddress)}/balances/usd/` // dead link
       `${url}/safes/${getAddress(safeAddress)}/balances/`
     );
 

--- a/libs/moloch-v3-fields/src/fields/RagequitTokenList.tsx
+++ b/libs/moloch-v3-fields/src/fields/RagequitTokenList.tsx
@@ -3,7 +3,6 @@ import { useFormContext } from 'react-hook-form';
 import {
   formatValueTo,
   memberTokenBalanceShare,
-  // memberUsdValueShare,
   NETWORK_TOKEN_ETH_ADDRESS,
 } from '@daohaus/utils';
 import { getNetwork } from '@daohaus/keychain-utils';
@@ -48,7 +47,6 @@ const DataColumn = styled(Column)`
 type TokenTable = {
   tokenCheckboxes: CheckboxProps[];
   amounts: React.ReactNode[];
-  // usdValue: React.ReactNode[];
 };
 
 export const RagequitTokenList = (props: Buildable<Field>) => {
@@ -139,29 +137,11 @@ export const RagequitTokenList = (props: Buildable<Field>) => {
             </DataSm>,
           ];
 
-          // acc.usdValue = [
-          //   ...acc.usdValue,
-          //   <DataSm key={token.tokenAddress}>
-          //     {formatValueTo({
-          //       value: memberUsdValueShare(
-          //         token.fiatBalance,
-          //         dao.totalShares || 0,
-          //         dao.totalLoot || 0,
-          //         sharesToBurn || 0,
-          //         lootToBurn || 0
-          //       ),
-          //       decimals: 2,
-          //       format: 'currency',
-          //     })}
-          //   </DataSm>,
-          // ];
-
           return acc;
         },
         {
           tokenCheckboxes: [],
           amounts: [],
-          // usdValue: []
         }
       );
   }, [
@@ -214,9 +194,6 @@ export const RagequitTokenList = (props: Buildable<Field>) => {
         <Column>
           <ParSm>Amount</ParSm>
         </Column>
-        {/* <Column>
-          <ParSm>USD Value</ParSm>
-        </Column> */}
       </TokenListContainer>
       <TokenListContainer>
         <Column>
@@ -227,7 +204,6 @@ export const RagequitTokenList = (props: Buildable<Field>) => {
           />
         </Column>
         <DataColumn>{tokenTable.amounts}</DataColumn>
-        {/* <DataColumn>{tokenTable.usdValue}</DataColumn> */}
       </TokenListContainer>
     </>
   );

--- a/libs/moloch-v3-macro-ui/src/components/DaoOverview/DaoOverview.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/DaoOverview/DaoOverview.tsx
@@ -36,14 +36,6 @@ export const DaoOverview = ({
           <OverviewCard>
             <DaoProfile dao={dao} />
             <DataGrid>
-              <DataIndicator
-                label="Total in Safes"
-                data={formatValueTo({
-                  value: dao.fiatTotal,
-                  decimals: 2,
-                  format: 'currencyShort',
-                })}
-              />
               <DataIndicator label="Members" data={dao.activeMemberCount} />
               <DataIndicator label="Proposals" data={dao.proposalCount} />
               <DataIndicator

--- a/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberProfileCard.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberProfileCard.tsx
@@ -1,10 +1,7 @@
 import { ValidNetwork } from '@daohaus/keychain-utils';
 import { MolochV3Member } from '@daohaus/moloch-v3-data';
 import { useDaoData, useProfile } from '@daohaus/moloch-v3-hooks';
-import {
-  ParLg,
-  Loading,
-} from '@daohaus/ui';
+import { ParLg, Loading } from '@daohaus/ui';
 
 import {
   AlertContainer,

--- a/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberProfileCard.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberProfileCard.tsx
@@ -1,16 +1,15 @@
 import { ValidNetwork } from '@daohaus/keychain-utils';
 import { MolochV3Member } from '@daohaus/moloch-v3-data';
 import { useDaoData, useProfile } from '@daohaus/moloch-v3-hooks';
-import { 
-  // DataIndicator, 
-  ParLg, Loading } from '@daohaus/ui';
-// import { formatValueTo, memberUsdValueShare } from '@daohaus/utils';
+import {
+  ParLg,
+  Loading,
+} from '@daohaus/ui';
 
 import {
   AlertContainer,
   LoadingContainer,
   MProfileCard,
-  // ValueRow,
 } from './MemberProfileCard.styles';
 import { MemberProfile } from './MemberProfile';
 import { MemberTokens } from './MemberTokens';
@@ -66,22 +65,6 @@ export const MemberProfileCard = ({
             allowLinks={allowLinks}
             allowMemberMenu={allowMemberMenu}
           />
-          {/* <ValueRow>
-            <DataIndicator
-              label="Total Exit Amount"
-              data={formatValueTo({
-                value: memberUsdValueShare(
-                  dao?.fiatTotal || 0,
-                  dao?.totalShares || 0,
-                  dao?.totalLoot || 0,
-                  member?.shares || 0,
-                  member?.loot || 0
-                ),
-                decimals: 2,
-                format: 'currency',
-              })}
-            />
-          </ValueRow> */}
           <MemberTokens daoChain={daoChain} dao={dao} member={member} />
         </>
       )}

--- a/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberTokens.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/MemberProfileCard/MemberTokens.tsx
@@ -9,7 +9,6 @@ import {
   charLimit,
   formatValueTo,
   memberTokenBalanceShare,
-  memberUsdValueShare,
   NETWORK_TOKEN_ETH_ADDRESS,
 } from '@daohaus/utils';
 
@@ -21,7 +20,6 @@ type TokenTableType = {
     name: string | undefined;
   };
   balance: string;
-  // fiatBalance: string;
 };
 
 type MemberTokensProps = {
@@ -53,17 +51,6 @@ export const MemberTokens = ({ daoChain, dao, member }: MemberTokensProps) => {
               address: bal.tokenAddress || NETWORK_TOKEN_ETH_ADDRESS,
               name: charLimit(bal.token?.name, 21),
             },
-            // fiatBalance: formatValueTo({
-            //   value: memberUsdValueShare(
-            //     bal.fiatBalance,
-            //     dao.totalShares || 0,
-            //     dao.totalLoot || 0,
-            //     member.shares || 0,
-            //     member.loot || 0
-            //   ),
-            //   decimals: 2,
-            //   format: 'currency',
-            // }),
             balance: formatValueTo({
               value: memberTokenBalanceShare(
                 bal.balance,
@@ -108,15 +95,6 @@ export const MemberTokens = ({ daoChain, dao, member }: MemberTokensProps) => {
           return <div>{value}</div>;
         },
       },
-      // {
-      //   Header: () => {
-      //     return <div>USD Value</div>;
-      //   },
-      //   accessor: 'fiatBalance',
-      //   Cell: ({ value }: { value: string }) => {
-      //     return <div>{value}</div>;
-      //   },
-      // },
     ],
     [daoChain, networks]
   );

--- a/libs/moloch-v3-macro-ui/src/components/SafeCard/SafeCard.tsx
+++ b/libs/moloch-v3-macro-ui/src/components/SafeCard/SafeCard.tsx
@@ -10,7 +10,7 @@ import {
   ParXs,
   Tag,
 } from '@daohaus/ui';
-import { formatValueTo, generateGnosisUiLink } from '@daohaus/utils';
+import { generateGnosisUiLink } from '@daohaus/utils';
 import { Keychain } from '@daohaus/keychain-utils';
 import { DataGrid } from '../Layout';
 import {
@@ -78,14 +78,6 @@ export const SafeCard = ({
           </div>
         </SafeCardHeader>
         <DataGrid>
-          {/* <DataIndicator
-            label="Balance"
-            data={formatValueTo({
-              value: safe.fiatTotal,
-              decimals: 2,
-              format: 'currencyShort',
-            })}
-          /> */}
           <DataIndicator label="Tokens" data={safe.tokenBalances.length} />
         </DataGrid>
       </SafeOverviewCard>

--- a/libs/utils/src/types/query.ts
+++ b/libs/utils/src/types/query.ts
@@ -12,7 +12,6 @@ export interface MolochV3Membership {
   delegatingTo?: string;
   isDelegate: boolean;
   memberAddress: string;
-  fiatTotal?: number;
   totalProposalCount: string;
   contractType: string;
   tokenBalances?: TokenBalance[];
@@ -38,7 +37,6 @@ export type TokenBalance = {
 };
 export type DaoTokenBalances = {
   safeAddress: string;
-  fiatTotal: number;
   tokenBalances: TokenBalance[];
 };
 export type AccountProfile = {

--- a/libs/utils/src/types/query.ts
+++ b/libs/utils/src/types/query.ts
@@ -31,9 +31,6 @@ export type TokenBalance = {
   balance: string;
   ethValue: string;
   timestamp: string;
-  fiatBalance: string;
-  fiatConversion: string;
-  fiatCode: string;
 };
 export type DaoTokenBalances = {
   safeAddress: string;

--- a/libs/utils/src/utils/general.ts
+++ b/libs/utils/src/utils/general.ts
@@ -37,6 +37,7 @@ export const memberTokenBalanceShare = (
   return memberSharesWei / 10 ** Number(decimals);
 };
 
+// if we have a usd value of the Safe, we can calculate the usd value of the member's shares
 export const memberUsdValueShare = (
   usdValue: string | number,
   daoTotalShares: string | number,


### PR DESCRIPTION
## GitHub Issue

[Add a link to the GitHub issue.](https://github.com/HausDAO/monorepo/issues/507)

## Changes

removes all fiat and usd refs for Safe token balances

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs locally
- [X] App builds locally (run the build command for _any impacted package_ and check for any errors before the PR)
